### PR TITLE
Bugfix/gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,6 +2580,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,6 @@ tracing-appender = "0.2"
 async-trait = "0.1"
 validator = { version = "0.18", features = ["derive"] }
 url = "2"
+base64 = "0.22"
 google-cloud-pubsub = "0.33.1"
 tower-http = { version = "0.6", features = ["trace"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,18 +1,18 @@
 //! CLI client commands: promises, tasks, schedules
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Subcommand};
 use serde_json::{json, Value};
 
 // ---- Serve args ----
 
-/// CLI flags for the `serve` subcommand.
+/// Common CLI flags shared between `serve` and `dev`.
 ///
 /// All fields are `Option<T>` (or plain `bool` for flags) so that only
 /// explicitly-provided values override the loaded configuration. Precedence:
 /// defaults < resonate.toml < env vars < these flags.
-#[derive(Parser, Default)]
-pub struct ServeArgs {
+#[derive(Args, Default)]
+pub struct CommonArgs {
     // --- Top-level ---
     /// Log level: debug, info, warn, error [default: info]
     #[arg(long)]
@@ -47,10 +47,6 @@ pub struct ServeArgs {
     /// Storage backend: sqlite or postgres [default: sqlite]
     #[arg(long = "storage-type")]
     pub storage_type: Option<String>,
-
-    /// SQLite database file path [default: resonate.db]
-    #[arg(long = "storage-sqlite-path", value_name = "PATH")]
-    pub sqlite_path: Option<String>,
 
     /// PostgreSQL connection URL
     #[arg(long = "storage-postgres-url", value_name = "URL")]
@@ -133,9 +129,8 @@ pub struct ServeArgs {
     pub observability_otlp_endpoint: Option<String>,
 }
 
-impl ServeArgs {
-    /// Apply any explicitly-provided CLI flags on top of an already-loaded `Config`.
-    pub fn apply(self, mut config: crate::config::Config) -> crate::config::Config {
+impl CommonArgs {
+    fn apply(self, mut config: crate::config::Config) -> crate::config::Config {
         if let Some(v) = self.level {
             config.level = v;
         }
@@ -167,9 +162,6 @@ impl ServeArgs {
 
         if let Some(v) = self.storage_type {
             config.storage.storage_type = v;
-        }
-        if let Some(v) = self.sqlite_path {
-            config.storage.sqlite.path = v;
         }
         if let Some(v) = self.postgres_url {
             config.storage.postgres.url = Some(v);
@@ -245,6 +237,49 @@ impl ServeArgs {
             config.observability.otlp_endpoint = v;
         }
 
+        config
+    }
+}
+
+/// CLI flags for the `serve` subcommand.
+#[derive(Args, Default)]
+pub struct ServeArgs {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
+    /// SQLite database file path [default: resonate.db]
+    #[arg(long = "storage-sqlite-path", value_name = "PATH")]
+    pub sqlite_path: Option<String>,
+}
+
+impl ServeArgs {
+    /// Apply any explicitly-provided CLI flags on top of an already-loaded `Config`.
+    pub fn apply(self, config: crate::config::Config) -> crate::config::Config {
+        let mut config = self.common.apply(config);
+        if let Some(v) = self.sqlite_path {
+            config.storage.sqlite.path = v;
+        }
+        config
+    }
+}
+
+/// CLI flags for the `dev` subcommand (same as `serve` but defaults SQLite to `:memory:`).
+#[derive(Args, Default)]
+pub struct DevArgs {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
+    /// SQLite database file path [default: :memory:]
+    #[arg(long = "storage-sqlite-path", value_name = "PATH")]
+    pub sqlite_path: Option<String>,
+}
+
+impl DevArgs {
+    /// Apply any explicitly-provided CLI flags on top of an already-loaded `Config`,
+    /// defaulting SQLite storage to `:memory:` if no path was given.
+    pub fn apply(self, config: crate::config::Config) -> crate::config::Config {
+        let mut config = self.common.apply(config);
+        config.storage.sqlite.path = self.sqlite_path.unwrap_or_else(|| ":memory:".to_string());
         config
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 //! CLI client commands: promises, tasks, schedules
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::{Args, Parser, Subcommand};
 use serde_json::{json, Value};
 
@@ -359,6 +360,16 @@ fn parse_json_flag(flag: &str, name: &str) -> Value {
         .unwrap_or_else(|e| error_exit(&format!("Invalid {} JSON: {}", name, e)))
 }
 
+fn b64_encode_data_field(v: &mut Value) {
+    if let Some(data) = v.get("data") {
+        let raw = match data {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        v["data"] = Value::String(STANDARD.encode(raw));
+    }
+}
+
 // ---- Global args ----
 
 #[derive(Args, Debug, Clone)]
@@ -481,7 +492,9 @@ pub async fn run_promises(args: PromiseArgs) {
             let timeout_at = now_ms() + dur;
             let mut data = json!({ "id": id, "timeoutAt": timeout_at });
             if let Some(p) = param {
-                data["param"] = parse_json_flag(p, "--param");
+                let mut param_val = parse_json_flag(p, "--param");
+                b64_encode_data_field(&mut param_val);
+                data["param"] = param_val;
             }
             if let Some(t) = tags {
                 data["tags"] = parse_json_flag(t, "--tags");
@@ -556,7 +569,9 @@ async fn settle(
 ) -> Result<Value, String> {
     let mut data = json!({ "id": id, "state": state });
     if let Some(v) = value {
-        data["value"] = parse_json_flag(v, "--value");
+        let mut value_val = parse_json_flag(v, "--value");
+        b64_encode_data_field(&mut value_val);
+        data["value"] = value_val;
     }
     post(server, "promise.settle", token, data).await
 }
@@ -904,12 +919,12 @@ pub async fn run_invoke(args: InvokeArgs) {
     });
     let param = json!({
         "headers": {},
-        "data": param.to_string(),
+        "data": STANDARD.encode(param.to_string()),
     });
 
     let mut tags = serde_json::Map::new();
     tags.insert(
-        "resonate:invoke".to_string(),
+        "resonate:target".to_string(),
         Value::String(args.target.clone()),
     );
     if delay_ms > 0 {
@@ -1017,7 +1032,9 @@ pub async fn run_schedules(args: ScheduleArgs) {
                 "promiseTimeout": timeout_ms,
             });
             if let Some(p) = promise_param {
-                data["promiseParam"] = parse_json_flag(p, "--promise-param");
+                let mut param_val = parse_json_flag(p, "--promise-param");
+                b64_encode_data_field(&mut param_val);
+                data["promiseParam"] = param_val;
             }
             if let Some(t) = promise_tags {
                 data["promiseTags"] = parse_json_flag(t, "--promise-tags");
@@ -1427,5 +1444,60 @@ mod tests {
     fn test_timeout_computation_compound() {
         let dur = parse_duration("1h30m").unwrap();
         assert_eq!(dur, 5_400_000); // 90 minutes
+    }
+
+    // ---- base64 encoding tests ----
+
+    #[test]
+    fn test_b64_encode_data_field_string() {
+        let mut v = json!({ "headers": {}, "data": "hello world" });
+        b64_encode_data_field(&mut v);
+        assert_eq!(v["data"], STANDARD.encode("hello world"));
+        assert_eq!(v["headers"], json!({}));
+    }
+
+    #[test]
+    fn test_b64_encode_data_field_json_object() {
+        let mut v = json!({ "headers": {}, "data": { "key": "value" } });
+        b64_encode_data_field(&mut v);
+        let expected = STANDARD.encode(r#"{"key":"value"}"#);
+        assert_eq!(v["data"], expected);
+    }
+
+    #[test]
+    fn test_b64_encode_data_field_no_data() {
+        let mut v = json!({ "headers": {} });
+        b64_encode_data_field(&mut v);
+        assert!(v.get("data").is_none());
+    }
+
+    #[test]
+    fn test_b64_encode_data_field_leaves_headers_untouched() {
+        let mut v = json!({ "headers": { "content-type": "application/json" }, "data": "raw" });
+        b64_encode_data_field(&mut v);
+        assert_eq!(v["headers"]["content-type"], "application/json");
+        assert_eq!(v["data"], STANDARD.encode("raw"));
+    }
+
+    #[test]
+    fn test_invoke_param_data_is_base64() {
+        let inner = json!({
+            "func": "myFunc",
+            "args": [1, "two"],
+            "version": 1,
+        });
+        let encoded = STANDARD.encode(inner.to_string());
+        let param = json!({ "headers": {}, "data": encoded });
+        // Verify the data field decodes back to the original JSON
+        let decoded = String::from_utf8(
+            base64::engine::general_purpose::STANDARD
+                .decode(param["data"].as_str().unwrap())
+                .unwrap(),
+        )
+        .unwrap();
+        let decoded_val: Value = serde_json::from_str(&decoded).unwrap();
+        assert_eq!(decoded_val["func"], "myFunc");
+        assert_eq!(decoded_val["args"][0], 1);
+        assert_eq!(decoded_val["version"], 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,12 +253,18 @@ async fn run_server(config: Config) -> Result<(), String> {
 
     let metrics_port = state.config.observability.metrics_port;
     if metrics_port > 0 {
+        let metrics_shutdown = shutdown_rx.clone();
         handles.push(tokio::spawn(async move {
             let metrics_app = Router::new().route("/metrics", get(metrics::metrics_handler));
             match tokio::net::TcpListener::bind(format!("0.0.0.0:{}", metrics_port)).await {
                 Ok(listener) => {
                     tracing::info!(port = metrics_port, "Metrics server listening");
-                    let _ = axum::serve(listener, metrics_app).await;
+                    let _ = axum::serve(listener, metrics_app)
+                        .with_graceful_shutdown(async move {
+                            let mut rx = metrics_shutdown;
+                            let _ = rx.wait_for(|v| *v).await;
+                        })
+                        .await;
                 }
                 Err(e) => {
                     tracing::error!(port = metrics_port, error = %e, "Failed to bind metrics port");
@@ -269,9 +275,11 @@ async fn run_server(config: Config) -> Result<(), String> {
 
     // Build HTTP router
     let effective_url = state.config.server.url.clone().unwrap_or_default();
+    let (sse_shutdown_tx, sse_shutdown_rx) = tokio::sync::watch::channel(false);
     let app_state = server::AppState {
         server: state,
         poll_registry,
+        sse_shutdown_rx,
     };
     let app = server::api_routes()
         .merge(server::poll_routes())
@@ -295,7 +303,10 @@ async fn run_server(config: Config) -> Result<(), String> {
     tracing::info!(bind = %bind, port = port, server_url = %effective_url, "Server listening");
 
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(async move {
+            shutdown_signal().await;
+            let _ = sse_shutdown_tx.send(true);
+        })
         .await
         .map_err(|e| format!("Server error: {e}"))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@ struct Cli {
 enum Commands {
     /// Start the Resonate server
     Serve(Box<cli::ServeArgs>),
+    /// Start the Resonate server with in-memory storage (ephemeral, for development)
+    Dev(Box<cli::DevArgs>),
     /// Promise operations
     #[command(alias = "promise")]
     Promises(cli::PromiseArgs),
@@ -75,6 +77,21 @@ async fn main() -> std::process::ExitCode {
             if let Err(e) = run_server(config).await {
                 // Tracing may not be initialized if the error occurred
                 // before tracing setup, so also write to stderr.
+                tracing::error!("{e}");
+                eprintln!("Fatal: {e}");
+                return std::process::ExitCode::FAILURE;
+            }
+        }
+        Commands::Dev(args) => {
+            let config = match Config::load() {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("Fatal: {e}");
+                    return std::process::ExitCode::FAILURE;
+                }
+            };
+            let config = args.apply(config);
+            if let Err(e) = run_server(config).await {
                 tracing::error!("{e}");
                 eprintln!("Fatal: {e}");
                 return std::process::ExitCode::FAILURE;

--- a/src/server.rs
+++ b/src/server.rs
@@ -61,6 +61,7 @@ impl Server {
 pub struct AppState {
     pub server: Arc<Server>,
     pub poll_registry: Arc<PollRegistry>,
+    pub sse_shutdown_rx: tokio::sync::watch::Receiver<bool>,
 }
 
 // Sub-state for API handlers — only needs the server.
@@ -82,6 +83,7 @@ impl axum::extract::FromRef<AppState> for ApiState {
 pub struct PollState {
     pub server: Arc<Server>,
     pub poll_registry: Arc<PollRegistry>,
+    pub sse_shutdown_rx: tokio::sync::watch::Receiver<bool>,
 }
 
 impl axum::extract::FromRef<AppState> for PollState {
@@ -89,6 +91,7 @@ impl axum::extract::FromRef<AppState> for PollState {
         PollState {
             server: state.server.clone(),
             poll_registry: state.poll_registry.clone(),
+            sse_shutdown_rx: state.sse_shutdown_rx.clone(),
         }
     }
 }
@@ -358,14 +361,33 @@ async fn handle_poll(
                 conn_id = conn.conn_id,
                 "Poll SSE connection established"
             );
+            let mut sse_shutdown = poll_state.sse_shutdown_rx.clone();
             let stream = async_stream::stream! {
                 let _guard = PollGuard {
                     registry: poll_state.poll_registry.clone(),
                     group: group.clone(),
                     conn_id: conn.conn_id,
                 };
-                while let Some(msg) = rx.recv().await {
-                    yield Ok::<_, std::convert::Infallible>(Event::default().data(msg));
+                loop {
+                    // Check synchronously first (no await — Ref is not held across a yield).
+                    if *sse_shutdown.borrow() {
+                        break;
+                    }
+                    tokio::select! {
+                        biased;
+                        result = sse_shutdown.changed() => {
+                            // Sender dropped or value changed; check if shutdown fired.
+                            if result.is_err() || *sse_shutdown.borrow() {
+                                break;
+                            }
+                        }
+                        msg = rx.recv() => {
+                            match msg {
+                                Some(msg) => yield Ok::<_, std::convert::Infallible>(Event::default().data(msg)),
+                                None => break,
+                            }
+                        }
+                    }
                 }
             };
 


### PR DESCRIPTION
This PR addresses three gaps in the CLI and server:

  1. dev subcommand for ephemeral local development
  2. Base64-encode data fields in promise/invoke payloads
  3. Graceful shutdown of SSE connections and the metrics server