### PR TITLE
feat: schedule promises using task-based timeout infrastructure

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -97,13 +97,6 @@ pub struct OutgoingUnblock {
     pub promise: PromiseRecord,
 }
 
-/// A single schedule run to be created as a promise.
-pub struct ScheduleRun {
-    pub id: String,
-    pub timeout_at: i64,
-    pub created_at: i64,
-}
-
 // === Parameter structs for Db trait methods ===
 
 pub struct PromiseCreateParams<'a> {
@@ -285,15 +278,14 @@ pub trait Db {
         limit: i64,
     ) -> StorageResult<Vec<ScheduleRecord>>;
 
-    fn schedule_run(
+    fn get_expired_schedule_timeouts(&self, time: i64) -> StorageResult<Vec<(String, i64)>>;
+
+    fn process_schedule_timeout(
         &self,
         schedule_id: &str,
-        last_run_at: i64,
+        fired_at: i64,
         next_run_at: i64,
-        runs: &[ScheduleRun],
     ) -> StorageResult<Option<ScheduleRecord>>;
-
-    fn get_expired_schedules(&self, time: i64) -> StorageResult<Vec<ScheduleRecord>>;
 
     // === Timeout processing ===
     fn process_timeouts(&self, time: i64) -> StorageResult<()>;

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -102,6 +102,12 @@ CREATE TABLE IF NOT EXISTS schedules (
   next_run_at BIGINT NOT NULL,
   last_run_at BIGINT
 );
+
+CREATE TABLE IF NOT EXISTS schedule_timeouts (
+  timeout_at BIGINT NOT NULL,
+  id TEXT PRIMARY KEY REFERENCES schedules(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_schedule_timeouts_timeout_at_id ON schedule_timeouts (timeout_at ASC, id ASC);
 ";
 
 impl PostgresStorage {
@@ -1623,6 +1629,13 @@ impl Db for PostgresDb<'_> {
               ON CONFLICT (id) DO NOTHING
               RETURNING *
             ),
+            inserted_or_skipped_stimeout AS (
+              INSERT INTO schedule_timeouts (timeout_at, id)
+              SELECT $9, $1
+              WHERE EXISTS (SELECT 1 FROM inserted_or_skipped_schedule)
+              ON CONFLICT (id) DO NOTHING
+              RETURNING id
+            ),
             result AS (
               SELECT * FROM inserted_or_skipped_schedule
               UNION ALL
@@ -1662,81 +1675,103 @@ impl Db for PostgresDb<'_> {
         Ok(rows.iter().map(row_to_schedule).collect())
     }
 
-    // S-02: schedule.run — single CTE with unnest
-    fn schedule_run(
+    fn get_expired_schedule_timeouts(&self, time: i64) -> StorageResult<Vec<(String, i64)>> {
+        let rows = rt_block_on(
+            sqlx::query("SELECT id, timeout_at FROM schedule_timeouts WHERE timeout_at <= $1")
+                .bind(time)
+                .fetch_all(self.tx().as_mut()),
+        )?;
+        Ok(rows
+            .iter()
+            .map(|r| (r.get::<String, _>("id"), r.get::<i64, _>("timeout_at")))
+            .collect())
+    }
+
+    fn process_schedule_timeout(
         &self,
         schedule_id: &str,
-        last_run_at: i64,
+        fired_at: i64,
         next_run_at: i64,
-        runs: &[super::ScheduleRun],
     ) -> StorageResult<Option<ScheduleRecord>> {
-        if runs.is_empty() {
-            // just update schedule timestamps
-            rt_block_on(
-                sqlx::query(
-                    "UPDATE schedules SET last_run_at = $2, next_run_at = $3 WHERE id = $1",
-                )
-                .bind(schedule_id)
-                .bind(last_run_at)
-                .bind(next_run_at)
-                .execute(self.tx().as_mut()),
-            )?;
-            return self.schedule_get(schedule_id);
-        }
-
-        // Extract arrays for unnest
-        let mut promise_ids: Vec<String> = Vec::new();
-        let mut timeout_ats: Vec<i64> = Vec::new();
-        let mut created_ats: Vec<i64> = Vec::new();
-        for run in runs {
-            promise_ids.push(run.id.clone());
-            timeout_ats.push(run.timeout_at);
-            created_ats.push(run.created_at);
-        }
-
-        let rows = rt_block_on(sqlx::query("
-            WITH
+        let trt = self.task_retry_timeout;
+        // Template substitution and address extraction happen inside the CTE.
+        // $1=schedule_id, $2=fired_at, $3=next_run_at
+        let rows = rt_block_on(sqlx::query(&format!("
+            WITH fired_stimeout AS (
+              SELECT st.id
+              FROM schedule_timeouts st
+              WHERE st.id = $1 AND st.timeout_at = $2
+            ),
             schedule AS (
-              SELECT * FROM schedules WHERE id = $1
+              SELECT *,
+                REPLACE(REPLACE(promise_id, '{{{{.id}}}}', id), '{{{{.timestamp}}}}', CAST($2 AS TEXT)) AS computed_promise_id,
+                ($2 + promise_timeout) AS computed_timeout_at,
+                (promise_tags->>'resonate:target') AS address
+              FROM schedules
+              WHERE id = $1
+                AND EXISTS (SELECT 1 FROM fired_stimeout)
             ),
-            runs AS (
-              SELECT * FROM unnest($4::text[], $5::bigint[], $6::bigint[])
-                AS t(id TEXT, timeout_at BIGINT, created_at BIGINT)
-            ),
-            inserted_or_skipped_promises AS (
+            inserted_or_skipped_promise AS (
               INSERT INTO promises (id, state, param_headers, param_data, tags, timeout_at, created_at)
-              SELECT r.id, 'pending', s.promise_param_headers, s.promise_param_data, s.promise_tags, r.timeout_at, r.created_at
-              FROM runs r, schedule s
+              SELECT s.computed_promise_id, 'pending',
+                s.promise_param_headers, s.promise_param_data, s.promise_tags,
+                s.computed_timeout_at, $2
+              FROM schedule s
               ON CONFLICT (id) DO NOTHING
               RETURNING *
             ),
-            inserted_ptimeouts AS (
+            inserted_or_skipped_ptimeout AS (
               INSERT INTO promise_timeouts (timeout_at, id)
-              SELECT timeout_at, id FROM inserted_or_skipped_promises
+              SELECT p.timeout_at, p.id FROM inserted_or_skipped_promise p
               ON CONFLICT (id) DO NOTHING
               RETURNING id
             ),
+            inserted_or_skipped_task AS (
+              INSERT INTO tasks (id, state)
+              SELECT p.id, 'pending'
+              FROM inserted_or_skipped_promise p
+              WHERE EXISTS (SELECT 1 FROM schedule s WHERE s.address IS NOT NULL)
+              ON CONFLICT (id) DO NOTHING
+              RETURNING id
+            ),
+            inserted_or_skipped_ttimeout AS (
+              INSERT INTO task_timeouts (timeout_at, id, timeout_type, ttl)
+              SELECT ($2 + {trt}), t.id, 0, {trt}
+              FROM inserted_or_skipped_task t
+              ON CONFLICT (id) DO NOTHING
+              RETURNING id
+            ),
+            inserted_or_updated_outgoing AS (
+              INSERT INTO outgoing_execute (id, version, address)
+              SELECT t.id, 0, s.address
+              FROM inserted_or_skipped_task t, schedule s
+              ON CONFLICT (id) DO UPDATE
+                SET version = EXCLUDED.version, address = EXCLUDED.address
+              RETURNING id
+            ),
             updated_schedule AS (
-              UPDATE schedules SET last_run_at = $2, next_run_at = $3 WHERE id = $1
+              UPDATE schedules SET last_run_at = $2, next_run_at = $3
+              WHERE id = $1
+                AND EXISTS (SELECT 1 FROM fired_stimeout)
               RETURNING *
+            ),
+            updated_stimeout AS (
+              UPDATE schedule_timeouts SET timeout_at = $3
+              WHERE id = $1
+                AND EXISTS (SELECT 1 FROM fired_stimeout)
+              RETURNING id
             )
             SELECT id, cron, promise_id, promise_timeout, promise_param_headers::text, promise_param_data, promise_tags::text, created_at, next_run_at, last_run_at FROM updated_schedule
-        ")
-            .bind(schedule_id).bind(last_run_at).bind(next_run_at)        // $1-$3
-            .bind(&promise_ids).bind(&timeout_ats).bind(&created_ats)     // $4-$6
+        ", trt = trt))
+            .bind(schedule_id)  // $1
+            .bind(fired_at)     // $2
+            .bind(next_run_at)  // $3
             .fetch_all(self.tx().as_mut()))?;
 
         if rows.is_empty() {
             return Ok(None);
         }
         Ok(Some(row_to_schedule(&rows[0])))
-    }
-
-    fn get_expired_schedules(&self, time: i64) -> StorageResult<Vec<ScheduleRecord>> {
-        let rows = rt_block_on(sqlx::query(
-            "SELECT id, cron, promise_id, promise_timeout, promise_param_headers::text, promise_param_data, promise_tags::text, created_at, next_run_at, last_run_at FROM schedules WHERE next_run_at <= $1")
-            .bind(time).fetch_all(self.tx().as_mut()))?;
-        Ok(rows.iter().map(row_to_schedule).collect())
     }
 
     fn ping(&self) -> StorageResult<()> {

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -124,6 +124,12 @@ fn create_schema(conn: &Connection) -> rusqlite::Result<()> {
           next_run_at BIGINT NOT NULL,
           last_run_at BIGINT
         );
+
+        CREATE TABLE IF NOT EXISTS schedule_timeouts (
+          timeout_at BIGINT NOT NULL,
+          id TEXT PRIMARY KEY REFERENCES schedules(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_schedule_timeouts_timeout_at_id ON schedule_timeouts (timeout_at ASC, id ASC);
         ",
     )?;
     Ok(())
@@ -1179,6 +1185,10 @@ impl<'a> Db for SqliteDb<'a> {
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![id, cron, promise_id, promise_timeout, promise_param_headers, promise_param_data, promise_tags, created_at, next_run_at],
         )?;
+        self.conn.execute(
+            "INSERT OR IGNORE INTO schedule_timeouts (timeout_at, id) VALUES (?1, ?2)",
+            params![next_run_at, id],
+        )?;
         Ok(self.schedule_get(id)?.unwrap())
     }
 
@@ -1209,61 +1219,107 @@ impl<'a> Db for SqliteDb<'a> {
         Ok(results)
     }
 
-    fn schedule_run(
+    fn get_expired_schedule_timeouts(&self, time: i64) -> StorageResult<Vec<(String, i64)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, timeout_at FROM schedule_timeouts WHERE timeout_at <= ?1")?;
+        let mut rows = stmt.query(params![time])?;
+        let mut results = Vec::new();
+        while let Some(row) = rows.next()? {
+            let id: String = row.get(0)?;
+            let timeout_at: i64 = row.get(1)?;
+            results.push((id, timeout_at));
+        }
+        Ok(results)
+    }
+
+    fn process_schedule_timeout(
         &self,
         schedule_id: &str,
-        last_run_at: i64,
+        fired_at: i64,
         next_run_at: i64,
-        runs: &[super::ScheduleRun],
     ) -> StorageResult<Option<ScheduleRecord>> {
+        // Step 1: Guard check — idempotency
+        let guard_exists: bool = self.conn.query_row(
+            "SELECT COUNT(*) FROM schedule_timeouts WHERE id = ?1 AND timeout_at = ?2",
+            params![schedule_id, fired_at],
+            |row| row.get::<_, i64>(0),
+        )? > 0;
+        if !guard_exists {
+            return Ok(None);
+        }
+
+        // Step 2: Fetch schedule
         let schedule = match self.schedule_get(schedule_id)? {
             Some(s) => s,
             None => return Ok(None),
         };
 
-        for run in runs {
-            let id = run.id.as_str();
-            let timeout_at = run.timeout_at;
-            let created_at = run.created_at;
+        // Step 3: Extract resonate:target address
+        let address = schedule.promise_tags.get("resonate:target").cloned();
 
-            let ph = schedule
-                .promise_param
-                .headers
-                .as_ref()
-                .map(|h| serde_json::to_string(h).unwrap());
-            let tags_json = serde_json::to_string(&schedule.promise_tags).unwrap();
+        // Step 4: Build promise ID and timeout
+        let promise_id = schedule
+            .promise_id
+            .replace("{{.id}}", &schedule.id)
+            .replace("{{.timestamp}}", &fired_at.to_string());
+        let promise_timeout_at = fired_at + schedule.promise_timeout;
 
+        // Step 5: Create promise
+        let ph = schedule
+            .promise_param
+            .headers
+            .as_ref()
+            .map(|h| serde_json::to_string(h).unwrap());
+        let tags_json = serde_json::to_string(&schedule.promise_tags).unwrap();
+        self.conn.execute(
+            "INSERT OR IGNORE INTO promises (id, state, param_headers, param_data, tags, timeout_at, created_at)
+             VALUES (?1, 'pending', ?2, ?3, ?4, ?5, ?6)",
+            params![promise_id, ph, schedule.promise_param.data, tags_json, promise_timeout_at, fired_at],
+        )?;
+        let promise_inserted = self.conn.changes() > 0;
+
+        if promise_inserted {
+            // Step 6: Create promise_timeout
             self.conn.execute(
-                "INSERT OR IGNORE INTO promises (id, state, param_headers, param_data, tags, timeout_at, created_at)
-                 VALUES (?1, 'pending', ?2, ?3, ?4, ?5, ?6)",
-                params![id, ph, schedule.promise_param.data, tags_json, timeout_at, created_at],
+                "INSERT OR IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?1, ?2)",
+                params![promise_timeout_at, promise_id],
             )?;
-            if self.conn.changes() > 0 {
+
+            // Step 7: Create task infrastructure if resonate:target is set
+            if let Some(addr) = &address {
                 self.conn.execute(
-                    "INSERT OR IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?1, ?2)",
-                    params![timeout_at, id],
+                    "INSERT OR IGNORE INTO tasks (id, state) VALUES (?1, 'pending')",
+                    params![promise_id],
                 )?;
+                if self.conn.changes() > 0 {
+                    self.conn.execute(
+                        "INSERT OR IGNORE INTO task_timeouts (timeout_at, id, timeout_type, ttl) VALUES (?1, ?2, 0, ?3)",
+                        params![fired_at + self.task_retry_timeout, promise_id, self.task_retry_timeout],
+                    )?;
+                    self.conn.execute(
+                        "INSERT INTO outgoing_execute (id, version, address) VALUES (?1, 0, ?2)
+                         ON CONFLICT (id) DO UPDATE SET version = EXCLUDED.version, address = EXCLUDED.address",
+                        params![promise_id, addr],
+                    )?;
+                }
             }
         }
 
+        // Step 8: Advance schedule
         self.conn.execute(
-            "UPDATE schedules SET last_run_at = ?2, next_run_at = ?3 WHERE id = ?1",
-            params![schedule_id, last_run_at, next_run_at],
+            "UPDATE schedules SET last_run_at = ?1, next_run_at = ?2 WHERE id = ?3",
+            params![fired_at, next_run_at, schedule_id],
         )?;
 
+        // Step 9: Advance schedule_timeout
+        self.conn.execute(
+            "UPDATE schedule_timeouts SET timeout_at = ?1 WHERE id = ?2",
+            params![next_run_at, schedule_id],
+        )?;
+
+        // Step 10: Return updated schedule
         self.schedule_get(schedule_id)
-    }
-
-    fn get_expired_schedules(&self, time: i64) -> StorageResult<Vec<ScheduleRecord>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, cron, promise_id, promise_timeout, promise_param_headers, promise_param_data, promise_tags, created_at, next_run_at, last_run_at FROM schedules WHERE next_run_at <= ?1",
-        )?;
-        let mut rows = stmt.query(params![time])?;
-        let mut results = Vec::new();
-        while let Some(row) = rows.next()? {
-            results.push(row_to_schedule(row)?);
-        }
-        Ok(results)
     }
 
     fn ping(&self) -> StorageResult<()> {

--- a/src/processing/processing_timeouts.rs
+++ b/src/processing/processing_timeouts.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::metrics;
-use crate::persistence::{Db, ScheduleRun, StorageResult};
+use crate::persistence::{Db, StorageResult};
 use crate::server::Server;
 use crate::util;
 
@@ -58,40 +58,31 @@ pub fn process_all_timeouts(db: &dyn Db, time: i64) -> StorageResult<()> {
 
 /// Process expired schedule timeouts.
 fn process_schedule_timeouts(db: &dyn Db, time: i64) -> StorageResult<()> {
-    let expired = db.get_expired_schedules(time)?;
-    for schedule in expired {
-        let mut cron_time = schedule.next_run_at;
-        let mut runs = Vec::new();
+    let expired = db.get_expired_schedule_timeouts(time)?;
 
-        while cron_time <= time {
-            let promise_id = schedule
-                .promise_id
-                .replace("{{.id}}", &schedule.id)
-                .replace("{{.timestamp}}", &cron_time.to_string());
+    for (schedule_id, fired_at) in &expired {
+        let schedule = match db.schedule_get(schedule_id)? {
+            Some(s) => s,
+            None => continue,
+        };
 
-            let timeout_at = cron_time + schedule.promise_timeout;
+        let next_run_at = util::compute_next_cron(&schedule.cron, *fired_at);
 
-            runs.push(ScheduleRun {
-                id: promise_id,
-                timeout_at,
-                created_at: cron_time,
-            });
-
-            let next = util::compute_next_cron(&schedule.cron, cron_time);
-            cron_time = next;
-        }
-
-        if !runs.is_empty() {
-            tracing::info!(
-                schedule_id = %schedule.id,
-                cron = %schedule.cron,
-                runs = runs.len(),
-                "Schedule triggered, creating promises"
-            );
-            metrics::SCHEDULE_PROMISES_TOTAL.inc_by(runs.len() as f64);
-            let last_run_at = runs.last().map(|r| r.created_at).unwrap();
-            db.schedule_run(&schedule.id, last_run_at, cron_time, &runs)?;
+        match db.process_schedule_timeout(schedule_id, *fired_at, next_run_at)? {
+            Some(_) => {
+                tracing::info!(
+                    schedule_id = %schedule_id,
+                    fired_at = fired_at,
+                    next_run_at = next_run_at,
+                    "Schedule fired"
+                );
+                metrics::SCHEDULE_PROMISES_TOTAL.inc();
+            }
+            None => {
+                // Idempotency guard fired or schedule was deleted — skip.
+            }
         }
     }
+
     Ok(())
 }


### PR DESCRIPTION
Replace get_expired_schedules/schedule_run with a schedule_timeouts table that mirrors promise_timeouts, enabling idempotent per-tick processing. Each schedule fire creates a promise (and task+outgoing if resonate:target is set) via a single CTE (postgres) or sequential steps (sqlite), then advances the schedule_timeouts row to next_run_at.