### PR TITLE
Cleanup

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -64,6 +64,7 @@ pub struct TaskCreateResult {
     pub promise: PromiseRecord,
     pub task_created: bool,
     pub task_state: Option<String>,
+    pub task_version: Option<i64>,
 }
 
 pub struct TaskAcquireResult {
@@ -245,7 +246,7 @@ pub trait Db {
     // === Task operations ===
     fn task_get(&self, id: &str) -> StorageResult<Option<TaskRecord>>;
 
-    fn task_create(&self, params: &TaskCreateParams) -> StorageResult<Option<TaskCreateResult>>;
+    fn task_create(&self, params: &TaskCreateParams) -> StorageResult<TaskCreateResult>;
 
     fn task_acquire(&self, params: &TaskAcquireParams) -> StorageResult<TaskAcquireResult>;
 

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -93,10 +93,16 @@ pub struct TaskSuspendResult {
 }
 
 pub struct TaskFulfillResult {
+    pub task_exists: bool,
     /// Whether the task was actually transitioned to fulfilled.
     pub task_fulfilled: bool,
     /// `None` when the promise was not found in the database.
     pub promise: Option<PromiseRecord>,
+}
+
+pub struct TaskReleaseResult {
+    pub task_released: bool,
+    pub task_exists: bool,
 }
 
 pub struct TaskHaltResult {
@@ -273,8 +279,13 @@ pub trait Db {
 
     fn task_fulfill(&self, params: &TaskFulfillParams) -> StorageResult<TaskFulfillResult>;
 
-    fn task_release(&self, task_id: &str, version: i64, time: i64, ttl: i64)
-        -> StorageResult<bool>;
+    fn task_release(
+        &self,
+        task_id: &str,
+        version: i64,
+        time: i64,
+        ttl: i64,
+    ) -> StorageResult<TaskReleaseResult>;
 
     fn task_halt(&self, task_id: &str) -> StorageResult<TaskHaltResult>;
 

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -76,6 +76,8 @@ pub struct TaskCreateResult {
 pub struct TaskAcquireResult {
     pub promise: Option<PromiseRecord>,
     pub was_acquired: bool,
+    pub task_state: Option<TaskState>,
+    pub task_version: Option<i64>,
 }
 
 pub struct TaskFenceResult {

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -48,6 +48,12 @@ impl From<sqlx::Error> for StorageError {
 
 // === Result types for CTE-based operations ===
 
+pub struct PromiseCreateResult {
+    /// Whether the promise was newly inserted (false = already existed).
+    pub was_created: bool,
+    pub promise: PromiseRecord,
+}
+
 pub struct PromiseSettleResult {
     /// Whether the promise was actually transitioned from pending to settled.
     pub was_settled: bool,
@@ -218,7 +224,7 @@ pub trait Db {
     // === Promise operations ===
     fn promise_get(&self, id: &str) -> StorageResult<Option<PromiseRecord>>;
 
-    fn promise_create(&self, params: &PromiseCreateParams) -> StorageResult<PromiseRecord>;
+    fn promise_create(&self, params: &PromiseCreateParams) -> StorageResult<PromiseCreateResult>;
 
     fn promise_settle(&self, params: &PromiseSettleParams) -> StorageResult<PromiseSettleResult>;
 

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -1,9 +1,9 @@
 use super::{
-    Db, OutgoingExecute, OutgoingUnblock, PromiseCreateParams, PromiseSettleParams,
-    PromiseSettleResult, RegisterCallbackResult, ScheduleCreateParams, StorageError, StorageResult,
-    TaskAcquireParams, TaskAcquireResult, TaskContinueResult, TaskCreateParams, TaskCreateResult,
-    TaskFenceCreateParams, TaskFenceResult, TaskFenceSettleParams, TaskFulfillParams,
-    TaskFulfillResult, TaskHaltResult, TaskSuspendResult,
+    Db, OutgoingExecute, OutgoingUnblock, PromiseCreateParams, PromiseCreateResult,
+    PromiseSettleParams, PromiseSettleResult, RegisterCallbackResult, ScheduleCreateParams,
+    StorageError, StorageResult, TaskAcquireParams, TaskAcquireResult, TaskContinueResult,
+    TaskCreateParams, TaskCreateResult, TaskFenceCreateParams, TaskFenceResult,
+    TaskFenceSettleParams, TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskSuspendResult,
 };
 use crate::types::{
     PromiseRecord, PromiseState, PromiseValue, ScheduleRecord, Snapshot, SnapshotCallback,
@@ -494,7 +494,7 @@ impl Db for PostgresDb<'_> {
     }
 
     // P-02: promise.create — single CTE
-    fn promise_create(&self, params: &PromiseCreateParams) -> StorageResult<PromiseRecord> {
+    fn promise_create(&self, params: &PromiseCreateParams) -> StorageResult<PromiseCreateResult> {
         let PromiseCreateParams {
             id,
             state,
@@ -551,22 +551,25 @@ impl Db for PostgresDb<'_> {
               RETURNING id
             ),
             result AS (
-              SELECT * FROM inserted_or_skipped_promise
+              SELECT *, TRUE AS was_created FROM inserted_or_skipped_promise
               UNION ALL
-              SELECT * FROM promises WHERE id = $1 AND NOT EXISTS (SELECT 1 FROM inserted_or_skipped_promise)
+              SELECT *, FALSE AS was_created FROM promises WHERE id = $1 AND NOT EXISTS (SELECT 1 FROM inserted_or_skipped_promise)
             )
-            SELECT id, state, param_headers::text, param_data, value_headers::text, value_data, tags::text, timeout_at, created_at, settled_at FROM result
+            SELECT id, state, param_headers::text, param_data, value_headers::text, value_data, tags::text, timeout_at, created_at, settled_at, was_created FROM result
         "))
             .bind(id).bind(state).bind(param_headers).bind(param_data).bind(tags)       // $1-$5
             .bind(timeout_at).bind(created_at).bind(settled_at)                           // $6-$8
             .bind(already_timedout).bind(address)                                         // $9-$10
             .fetch_all(self.tx().as_mut()))?;
 
-        // Fallback: under READ COMMITTED, a concurrent insert can cause the CTE to return 0 rows
         if rows.is_empty() {
-            return Ok(self.promise_get(id)?.unwrap());
+            unreachable!("promise_create CTE returned no rows");
         }
-        Ok(row_to_promise(&rows[0]))
+        let was_created: bool = rows[0].get("was_created");
+        Ok(PromiseCreateResult {
+            was_created,
+            promise: row_to_promise(&rows[0]),
+        })
     }
 
     // P-03: promise.settle — lock preamble + CTE

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -799,8 +799,8 @@ impl Db for PostgresDb<'_> {
     fn task_get(&self, id: &str) -> StorageResult<Option<TaskRecord>> {
         let row = rt_block_on(sqlx::query("
             SELECT t.id, t.state, t.version,
-              CASE WHEN tt.timeout_type = 1 THEN tt.ttl ELSE NULL END AS ttl,
-              CASE WHEN tt.timeout_type = 1 THEN tt.process_id ELSE NULL END AS pid,
+              CASE WHEN t.state = 'acquired' THEN tt.ttl ELSE NULL END AS ttl,
+              CASE WHEN t.state = 'acquired' THEN tt.process_id ELSE NULL END AS pid,
               COALESCE(
                 (SELECT COUNT(*)::INT FROM callbacks c WHERE c.awaiter_id = t.id AND c.ready = true),
                 0
@@ -1587,8 +1587,8 @@ impl Db for PostgresDb<'_> {
     ) -> StorageResult<Vec<TaskRecord>> {
         let rows = rt_block_on(sqlx::query("
             SELECT t.id, t.state, t.version,
-              CASE WHEN tt.timeout_type = 1 THEN tt.ttl ELSE NULL END AS ttl,
-              CASE WHEN tt.timeout_type = 1 THEN tt.process_id ELSE NULL END AS pid,
+              CASE WHEN t.state = 'acquired' THEN tt.ttl ELSE NULL END AS ttl,
+              CASE WHEN t.state = 'acquired' THEN tt.process_id ELSE NULL END AS pid,
               COALESCE(
                 (SELECT COUNT(*)::INT FROM callbacks c WHERE c.awaiter_id = t.id AND c.ready = true),
                 0
@@ -1984,8 +1984,8 @@ impl Db for PostgresDb<'_> {
 
         let task_rows = rt_block_on(sqlx::query("
             SELECT t.id, t.state, t.version,
-              CASE WHEN tt.timeout_type = 1 THEN tt.ttl ELSE NULL END AS ttl,
-              CASE WHEN tt.timeout_type = 1 THEN tt.process_id ELSE NULL END AS pid,
+              CASE WHEN t.state = 'acquired' THEN tt.ttl ELSE NULL END AS ttl,
+              CASE WHEN t.state = 'acquired' THEN tt.process_id ELSE NULL END AS pid,
               COALESCE(
                 (SELECT COUNT(*)::INT FROM callbacks c WHERE c.awaiter_id = t.id AND c.ready = true),
                 0

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -3,7 +3,8 @@ use super::{
     PromiseSettleParams, PromiseSettleResult, RegisterCallbackResult, ScheduleCreateParams,
     StorageError, StorageResult, TaskAcquireParams, TaskAcquireResult, TaskContinueResult,
     TaskCreateParams, TaskCreateResult, TaskFenceCreateParams, TaskFenceResult,
-    TaskFenceSettleParams, TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskSuspendResult,
+    TaskFenceSettleParams, TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskReleaseResult,
+    TaskSuspendResult,
 };
 use crate::types::{
     PromiseRecord, PromiseState, PromiseValue, ScheduleRecord, Snapshot, SnapshotCallback,
@@ -1256,16 +1257,11 @@ impl Db for PostgresDb<'_> {
     ) -> StorageResult<TaskSuspendResult> {
         let awaited_ids: Vec<String> = awaited_ids.iter().map(|s| s.to_string()).collect();
 
-        // Statement 1: acquire locks — promises first, then task (consistent lock ordering)
+        // Statement 1: lock awaited promises (task row already locked by lock_for_update)
         rt_block_on(
             sqlx::query("SELECT id FROM promises WHERE id = ANY($1) FOR UPDATE")
                 .bind(&awaited_ids)
                 .fetch_all(self.tx().as_mut()),
-        )?;
-        rt_block_on(
-            sqlx::query("SELECT id FROM tasks WHERE id = $1 FOR UPDATE")
-                .bind(task_id)
-                .fetch_optional(self.tx().as_mut()),
         )?;
 
         // Statement 2: fresh snapshot — sees all callbacks/timeouts committed before this point
@@ -1358,25 +1354,6 @@ impl Db for PostgresDb<'_> {
         } = *params;
         let trt = self.task_retry_timeout;
 
-        // Statement 1: lock preamble — promise first, then task (consistent lock ordering)
-        rt_block_on(
-            sqlx::query(
-                "
-            WITH lock_promise AS (
-              SELECT id FROM promises WHERE id = $1 FOR UPDATE
-            ),
-            lock_task AS (
-              SELECT id FROM tasks WHERE id = $2 FOR UPDATE
-            )
-            SELECT 1
-        ",
-            )
-            .bind(promise_id)
-            .bind(task_id)
-            .fetch_optional(self.tx().as_mut()),
-        )?;
-
-        // Statement 2: fresh snapshot — sees all callbacks/timeouts committed before this point
         let rows = rt_block_on(sqlx::query(&format!("
             WITH fulfilled_acquired_task AS (
               UPDATE tasks SET state = 'fulfilled'
@@ -1441,11 +1418,11 @@ impl Db for PostgresDb<'_> {
               DELETE FROM listeners WHERE promise_id = $3 AND EXISTS (SELECT 1 FROM updated_promise) RETURNING promise_id
             ),
             result AS (
-              SELECT *, EXISTS (SELECT 1 FROM fulfilled_acquired_task) AS task_fulfilled FROM updated_promise
+              SELECT *, EXISTS (SELECT 1 FROM fulfilled_acquired_task) AS task_fulfilled, EXISTS (SELECT 1 FROM tasks WHERE id = $1) AS task_exists FROM updated_promise
               UNION ALL
-              SELECT *, EXISTS (SELECT 1 FROM fulfilled_acquired_task) AS task_fulfilled FROM promises WHERE id = $3 AND NOT EXISTS (SELECT 1 FROM updated_promise)
+              SELECT *, EXISTS (SELECT 1 FROM fulfilled_acquired_task) AS task_fulfilled, EXISTS (SELECT 1 FROM tasks WHERE id = $1) AS task_exists FROM promises WHERE id = $3 AND NOT EXISTS (SELECT 1 FROM updated_promise)
             )
-            SELECT id, state, param_headers::text, param_data, value_headers::text, value_data, tags::text, timeout_at, created_at, settled_at, task_fulfilled FROM result
+            SELECT id, state, param_headers::text, param_data, value_headers::text, value_data, tags::text, timeout_at, created_at, settled_at, task_fulfilled, task_exists FROM result
         "))
             .bind(task_id).bind(version as i32)                                       // $1-$2
             .bind(promise_id).bind(state).bind(value_headers).bind(value_data).bind(settled_at)  // $3-$7
@@ -1453,13 +1430,16 @@ impl Db for PostgresDb<'_> {
 
         if rows.is_empty() {
             return Ok(TaskFulfillResult {
+                task_exists: false,
                 task_fulfilled: false,
                 promise: None,
             });
         }
         let row = &rows[0];
         let task_fulfilled: bool = row.get("task_fulfilled");
+        let task_exists: bool = row.get("task_exists");
         Ok(TaskFulfillResult {
+            task_exists,
             task_fulfilled,
             promise: Some(row_to_promise(row)),
         })
@@ -1472,8 +1452,8 @@ impl Db for PostgresDb<'_> {
         version: i64,
         time: i64,
         ttl: i64,
-    ) -> StorageResult<bool> {
-        let rows = rt_block_on(
+    ) -> StorageResult<TaskReleaseResult> {
+        let row = rt_block_on(
             sqlx::query(
                 "
             WITH released_task AS (
@@ -1495,7 +1475,9 @@ impl Db for PostgresDb<'_> {
               ON CONFLICT (id) DO UPDATE SET version = EXCLUDED.version, address = EXCLUDED.address
               RETURNING id
             )
-            SELECT EXISTS (SELECT 1 FROM released_task) AS released
+            SELECT
+              EXISTS (SELECT 1 FROM released_task) AS task_released,
+              EXISTS (SELECT 1 FROM tasks WHERE id = $1) AS task_exists
         ",
             )
             .bind(task_id)
@@ -1505,7 +1487,10 @@ impl Db for PostgresDb<'_> {
             .fetch_one(self.tx().as_mut()),
         )?;
 
-        Ok(rows.get("released"))
+        Ok(TaskReleaseResult {
+            task_released: row.get("task_released"),
+            task_exists: row.get("task_exists"),
+        })
     }
 
     // T-09: task.halt — single CTE

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -822,7 +822,7 @@ impl Db for PostgresDb<'_> {
     }
 
     // T-02: task.create — single CTE
-    fn task_create(&self, params: &TaskCreateParams) -> StorageResult<Option<TaskCreateResult>> {
+    fn task_create(&self, params: &TaskCreateParams) -> StorageResult<TaskCreateResult> {
         let TaskCreateParams {
             promise_id,
             state,
@@ -842,12 +842,10 @@ impl Db for PostgresDb<'_> {
             "acquired"
         };
 
-        let trt = self.task_retry_timeout;
-
         // Statement 1: Promise creation CTE — inserts promise + task (if new).
         // NO acquired_task — task acquire is done as a separate statement
         // so it gets a fresh READ COMMITTED snapshot.
-        let rows = rt_block_on(sqlx::query(&format!("
+        let rows = rt_block_on(sqlx::query("
             WITH inserted_promise AS (
               INSERT INTO promises (id, state, param_headers, param_data, tags, timeout_at, created_at, settled_at)
               VALUES ($1, $2, $3::jsonb, $4, $5::jsonb, $6, $7, $8)
@@ -869,8 +867,8 @@ impl Db for PostgresDb<'_> {
               RETURNING *
             ),
             inserted_ttimeout AS (
-              INSERT INTO task_timeouts (timeout_at, id, timeout_type, ttl)
-              SELECT ($7 + {trt}), $1, 0, {trt}
+              INSERT INTO task_timeouts (timeout_at, id, timeout_type, process_id, ttl)
+              SELECT ($7 + $10), $1, 1, $11, $10
               WHERE NOT $9 AND EXISTS (SELECT 1 FROM inserted_task)
               ON CONFLICT (id) DO NOTHING
               RETURNING id
@@ -882,53 +880,40 @@ impl Db for PostgresDb<'_> {
             )
             SELECT
               p.id, p.state, p.param_headers::text, p.param_data, p.value_headers::text, p.value_data, p.tags::text, p.timeout_at, p.created_at, p.settled_at,
-              EXISTS (SELECT 1 FROM inserted_task) AS task_created
+              EXISTS (SELECT 1 FROM inserted_task) AS task_created,
+              t.state   AS task_state,
+              t.version AS task_version
             FROM promise p
-        "))
+            LEFT JOIN tasks t ON t.id = p.id
+        ")
             .bind(promise_id).bind(state).bind(param_headers).bind(param_data).bind(tags) // $1-$5
             .bind(timeout_at).bind(created_at).bind(settled_at)                             // $6-$8
             .bind(already_timedout).bind(ttl).bind(pid).bind(task_initial_state)             // $9-$12
             .fetch_all(self.tx().as_mut()))?;
 
         if rows.is_empty() {
-            let promise = match self.promise_get(promise_id)? {
-                Some(p) => p,
-                None => return Ok(None),
-            };
-            return Ok(Some(TaskCreateResult {
-                promise,
-                task_created: false,
-                task_state: None,
-            }));
+            unreachable!("task_create CTE returned no rows");
         }
         let row = &rows[0];
         let promise = row_to_promise(row);
         let task_created: bool = row.get("task_created");
 
         if task_created {
-            // New task created — set up lease timeout
-            if !already_timedout {
-                rt_block_on(sqlx::query(
-                    "INSERT INTO task_timeouts (timeout_at, id, timeout_type, process_id, ttl)
-                     VALUES ($1, $2, 1, $3, $4)
-                     ON CONFLICT (id) DO UPDATE SET timeout_at = $1, timeout_type = 1, process_id = $3, ttl = $4")
-                    .bind(created_at + ttl).bind(promise_id).bind(pid).bind(ttl)
-                    .fetch_optional(self.tx().as_mut()))?;
-            }
-            return Ok(Some(TaskCreateResult {
+            return Ok(TaskCreateResult {
                 promise,
                 task_created: true,
                 task_state: Some(task_initial_state.to_string()),
-            }));
+                task_version: Some(if already_timedout { 0 } else { 1 }),
+            });
         }
 
         // Promise already existed, task not created.
-        // Acquire is done by the handler as a separate statement (fresh snapshot).
-        Ok(Some(TaskCreateResult {
+        Ok(TaskCreateResult {
             promise,
             task_created: false,
-            task_state: None,
-        }))
+            task_state: row.try_get("task_state").ok(),
+            task_version: row.try_get::<i32, _>("task_version").ok().map(|v| v as i64),
+        })
     }
 
     // T-03: task.acquire — single CTE

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -884,8 +884,8 @@ impl Db for PostgresDb<'_> {
             SELECT
               p.id, p.state, p.param_headers::text, p.param_data, p.value_headers::text, p.value_data, p.tags::text, p.timeout_at, p.created_at, p.settled_at,
               EXISTS (SELECT 1 FROM inserted_task) AS task_created,
-              t.state   AS task_state,
-              t.version AS task_version
+              COALESCE((SELECT state FROM inserted_task), t.state)   AS task_state,
+              COALESCE((SELECT version FROM inserted_task), t.version) AS task_version
             FROM promise p
             LEFT JOIN tasks t ON t.id = p.id
         ")
@@ -947,10 +947,13 @@ impl Db for PostgresDb<'_> {
               RETURNING *
             ),
             invoked AS (
-              SELECT p.*, EXISTS (SELECT 1 FROM acquired_task) AS was_acquired
+              SELECT p.*,
+                     (SELECT state FROM acquired_task) AS task_state,
+                     (SELECT version FROM acquired_task) AS task_version,
+                     EXISTS (SELECT 1 FROM acquired_task) AS was_acquired
               FROM promises p JOIN tasks t ON t.id = p.id WHERE p.id = $1
             )
-            SELECT id, state, param_headers::text, param_data, value_headers::text, value_data, tags::text, timeout_at, created_at, settled_at, was_acquired FROM invoked
+            SELECT id, state, param_headers::text, param_data, value_headers::text, value_data, tags::text, timeout_at, created_at, settled_at, task_state, task_version, was_acquired FROM invoked
         ")
             .bind(task_id).bind(version as i32).bind(time).bind(ttl).bind(pid)
             .fetch_all(self.tx().as_mut()))?;
@@ -959,13 +962,22 @@ impl Db for PostgresDb<'_> {
             return Ok(TaskAcquireResult {
                 promise: None,
                 was_acquired: false,
+                task_state: None,
+                task_version: None,
             });
         }
         let row = &rows[0];
         let was_acquired: bool = row.get("was_acquired");
+        let task_state: Option<TaskState> = row
+            .get::<Option<String>, _>("task_state")
+            .map(|s| parse_task_state(&s));
+        let task_version: Option<i64> =
+            row.try_get::<i32, _>("task_version").ok().map(|v| v as i64);
         Ok(TaskAcquireResult {
             promise: Some(row_to_promise(row)),
             was_acquired,
+            task_state,
+            task_version,
         })
     }
 

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -6,7 +6,7 @@ use super::{
     PromiseSettleParams, PromiseSettleResult, RegisterCallbackResult, ScheduleCreateParams,
     StorageResult, TaskAcquireParams, TaskAcquireResult, TaskContinueResult, TaskCreateParams,
     TaskCreateResult, TaskFenceCreateParams, TaskFenceResult, TaskFenceSettleParams,
-    TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskSuspendResult,
+    TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskReleaseResult, TaskSuspendResult,
 };
 use crate::types::{
     PromiseRecord, PromiseState, PromiseValue, ScheduleRecord, Snapshot, SnapshotCallback,
@@ -1001,7 +1001,13 @@ impl<'a> Db for SqliteDb<'a> {
             )?;
         }
 
+        let task_exists = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM tasks WHERE id = ?1)",
+            params![task_id],
+            |r| r.get::<_, bool>(0),
+        )?;
         Ok(TaskFulfillResult {
+            task_exists,
             task_fulfilled,
             promise: self.promise_get(promise_id)?,
         })
@@ -1013,18 +1019,22 @@ impl<'a> Db for SqliteDb<'a> {
         version: i64,
         time: i64,
         ttl: i64,
-    ) -> StorageResult<bool> {
-        let released = self.conn.execute(
+    ) -> StorageResult<TaskReleaseResult> {
+        let task_released = self.conn.execute(
             "UPDATE tasks SET state = 'pending' WHERE id = ?1 AND version = ?2 AND state = 'acquired'",
             params![task_id, version],
         )? > 0;
+        let task_exists = self.conn.query_row(
+            "SELECT EXISTS (SELECT 1 FROM tasks WHERE id = ?1)",
+            params![task_id],
+            |r| r.get(0),
+        )?;
 
-        if released {
+        if task_released {
             self.conn.execute(
                 "UPDATE task_timeouts SET timeout_type = 0, timeout_at = ?1, process_id = NULL WHERE id = ?2",
                 params![time + ttl, task_id],
             )?;
-            // Insert outgoing execute
             let new_version: i64 = self.conn.query_row(
                 "SELECT version FROM tasks WHERE id = ?1",
                 params![task_id],
@@ -1047,7 +1057,10 @@ impl<'a> Db for SqliteDb<'a> {
                 )?;
             }
         }
-        Ok(released)
+        Ok(TaskReleaseResult {
+            task_released,
+            task_exists,
+        })
     }
 
     fn task_halt(&self, task_id: &str) -> StorageResult<TaskHaltResult> {

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -636,8 +636,8 @@ impl<'a> Db for SqliteDb<'a> {
     fn task_get(&self, id: &str) -> StorageResult<Option<TaskRecord>> {
         let mut stmt = self.conn.prepare(
             "SELECT t.id, t.state, t.version,
-                    CASE WHEN tt.timeout_type = 1 THEN tt.ttl ELSE NULL END,
-                    CASE WHEN tt.timeout_type = 1 THEN tt.process_id ELSE NULL END
+                    CASE WHEN t.state = 'acquired' THEN tt.ttl ELSE NULL END,
+                    CASE WHEN t.state = 'acquired' THEN tt.process_id ELSE NULL END
              FROM tasks t LEFT JOIN task_timeouts tt ON tt.id = t.id
              WHERE t.id = ?1",
         )?;
@@ -1120,8 +1120,8 @@ impl<'a> Db for SqliteDb<'a> {
     ) -> StorageResult<Vec<TaskRecord>> {
         let mut stmt = self.conn.prepare(
             "SELECT t.id, t.state, t.version,
-                    CASE WHEN tt.timeout_type = 1 THEN tt.ttl ELSE NULL END,
-                    CASE WHEN tt.timeout_type = 1 THEN tt.process_id ELSE NULL END
+                    CASE WHEN t.state = 'acquired' THEN tt.ttl ELSE NULL END,
+                    CASE WHEN t.state = 'acquired' THEN tt.process_id ELSE NULL END
              FROM tasks t LEFT JOIN task_timeouts tt ON tt.id = t.id
              WHERE (?1 IS NULL OR t.state = ?1) AND (?2 IS NULL OR t.id > ?2)
              ORDER BY t.id ASC LIMIT ?3",
@@ -1550,8 +1550,8 @@ impl<'a> Db for SqliteDb<'a> {
 
         let mut stmt = conn.prepare(
             "SELECT t.id, t.state, t.version,
-                    CASE WHEN tt.timeout_type = 1 THEN tt.ttl ELSE NULL END,
-                    CASE WHEN tt.timeout_type = 1 THEN tt.process_id ELSE NULL END
+                    CASE WHEN t.state = 'acquired' THEN tt.ttl ELSE NULL END,
+                    CASE WHEN t.state = 'acquired' THEN tt.process_id ELSE NULL END
              FROM tasks t LEFT JOIN task_timeouts tt ON tt.id = t.id ORDER BY t.id",
         )?;
         let tasks: Vec<TaskRecord> = {

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -656,7 +656,7 @@ impl<'a> Db for SqliteDb<'a> {
         }
     }
 
-    fn task_create(&self, params: &TaskCreateParams) -> StorageResult<Option<TaskCreateResult>> {
+    fn task_create(&self, params: &TaskCreateParams) -> StorageResult<TaskCreateResult> {
         let TaskCreateParams {
             promise_id,
             state,
@@ -677,10 +677,9 @@ impl<'a> Db for SqliteDb<'a> {
             params![promise_id, state, param_headers, param_data, tags, timeout_at, created_at, settled_at],
         )? > 0;
 
-        let promise = match self.promise_get(promise_id)? {
-            Some(p) => p,
-            None => return Ok(None),
-        };
+        let promise = self
+            .promise_get(promise_id)?
+            .unwrap_or_else(|| unreachable!("promise missing after insert in task_create"));
 
         let mut task_created = false;
 
@@ -718,11 +717,12 @@ impl<'a> Db for SqliteDb<'a> {
 
         // SQLite: read task state for the result
         let task_row = self.task_get(promise_id)?;
-        Ok(Some(TaskCreateResult {
+        Ok(TaskCreateResult {
             promise,
             task_created,
             task_state: task_row.as_ref().map(|t| t.state.to_string()),
-        }))
+            task_version: task_row.as_ref().map(|t| t.version),
+        })
     }
 
     fn task_acquire(&self, params: &TaskAcquireParams) -> StorageResult<TaskAcquireResult> {

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -2,11 +2,11 @@ use rusqlite::{params, Connection};
 use std::sync::{Arc, Mutex};
 
 use super::{
-    Db, OutgoingExecute, OutgoingUnblock, PromiseCreateParams, PromiseSettleParams,
-    PromiseSettleResult, RegisterCallbackResult, ScheduleCreateParams, StorageResult,
-    TaskAcquireParams, TaskAcquireResult, TaskContinueResult, TaskCreateParams, TaskCreateResult,
-    TaskFenceCreateParams, TaskFenceResult, TaskFenceSettleParams, TaskFulfillParams,
-    TaskFulfillResult, TaskHaltResult, TaskSuspendResult,
+    Db, OutgoingExecute, OutgoingUnblock, PromiseCreateParams, PromiseCreateResult,
+    PromiseSettleParams, PromiseSettleResult, RegisterCallbackResult, ScheduleCreateParams,
+    StorageResult, TaskAcquireParams, TaskAcquireResult, TaskContinueResult, TaskCreateParams,
+    TaskCreateResult, TaskFenceCreateParams, TaskFenceResult, TaskFenceSettleParams,
+    TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskSuspendResult,
 };
 use crate::types::{
     PromiseRecord, PromiseState, PromiseValue, ScheduleRecord, Snapshot, SnapshotCallback,
@@ -439,7 +439,7 @@ impl<'a> Db for SqliteDb<'a> {
         }
     }
 
-    fn promise_create(&self, params: &PromiseCreateParams) -> StorageResult<PromiseRecord> {
+    fn promise_create(&self, params: &PromiseCreateParams) -> StorageResult<PromiseCreateResult> {
         let PromiseCreateParams {
             id,
             state,
@@ -458,8 +458,9 @@ impl<'a> Db for SqliteDb<'a> {
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![id, state, param_headers, param_data, tags, timeout_at, created_at, settled_at],
         )?;
+        let was_created = inserted > 0;
 
-        if inserted > 0 {
+        if was_created {
             if already_timedout {
                 // Already timed out — create fulfilled task if resonate:target
                 if address.is_some() {
@@ -495,7 +496,10 @@ impl<'a> Db for SqliteDb<'a> {
             }
         }
 
-        Ok(self.promise_get(id)?.unwrap())
+        Ok(PromiseCreateResult {
+            was_created,
+            promise: self.promise_get(id)?.unwrap(),
+        })
     }
 
     fn promise_settle(&self, params: &PromiseSettleParams) -> StorageResult<PromiseSettleResult> {
@@ -795,7 +799,7 @@ impl<'a> Db for SqliteDb<'a> {
         }
 
         // Execute inner promise.create
-        let promise = self.promise_create(&PromiseCreateParams {
+        let result = self.promise_create(&PromiseCreateParams {
             id: promise_id,
             state,
             param_headers,
@@ -811,7 +815,7 @@ impl<'a> Db for SqliteDb<'a> {
         Ok(TaskFenceResult {
             task_exists,
             fence_ok,
-            promise: Some(promise),
+            promise: Some(result.promise),
         })
     }
 

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -743,12 +743,16 @@ impl<'a> Db for SqliteDb<'a> {
         )?;
 
         let promise = self.promise_get(task_id)?;
-        if promise.is_none() || self.task_get(task_id)?.is_none() {
+        let task = self.task_get(task_id)?;
+        if promise.is_none() || task.is_none() {
             return Ok(TaskAcquireResult {
                 promise: None,
                 was_acquired: false,
+                task_state: None,
+                task_version: None,
             });
         }
+        let task = task.unwrap();
 
         if updated > 0 {
             // Insert/update lease timeout
@@ -767,6 +771,8 @@ impl<'a> Db for SqliteDb<'a> {
         Ok(TaskAcquireResult {
             promise,
             was_acquired: updated > 0,
+            task_state: Some(task.state),
+            task_version: Some(task.version),
         })
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1118,7 +1118,16 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
             db.try_timeout(&[action_id], now)?;
             // Lock preamble: ensures CTE and subsequent reads see
             // current state under READ COMMITTED.
-            let _ = db.lock_for_update(action_id)?;
+            let (promise_exists, task_exists) = db.lock_for_update(action_id)?;
+            if promise_exists && !task_exists {
+                tracing::debug!(task_id = %action_id, "Task create: promise exists without a target task");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    422,
+                    "Promise exists without a target task",
+                ));
+            }
             let tags_json = serde_json::to_string(&action_data.tags).unwrap();
             let already_timedout = now >= action_data.timeout_at;
             let (p_state, created_at, settled_at) = if already_timedout {
@@ -1317,6 +1326,16 @@ async fn op_task_acquire(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                 ));
             }
             db.try_timeout(&[&r.id], now)?;
+            let (_, task_exists) = db.lock_for_update(&r.id)?;
+            if !task_exists {
+                tracing::debug!(task_id = %r.id, "Task acquire: task not found");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
             let result = db.task_acquire(&TaskAcquireParams {
                 task_id: &r.id,
                 version: r.version,
@@ -1403,6 +1422,16 @@ async fn op_task_release(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                 ));
             }
             db.try_timeout(&[&r.id], now)?;
+            let (_, task_exists) = db.lock_for_update(&r.id)?;
+            if !task_exists {
+                tracing::debug!(task_id = %r.id, "Task release: task not found");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
             let result = db.task_release(&r.id, r.version, now, db.task_retry_timeout())?;
             if result.task_released {
                 tracing::info!(task_id = %r.id, version = r.version, "Task released back to pending");
@@ -1472,7 +1501,16 @@ async fn op_task_fulfill(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
             db.try_timeout(&[&action_data.id], now)?;
             // Lock preamble: lock promise + task to prevent stale snapshot
             // in precondition check and fulfillment CTE.
-            let _ = db.lock_for_update(&r.id)?;
+            let (_, task_exists) = db.lock_for_update(&r.id)?;
+            if !task_exists {
+                tracing::debug!(task_id = %r.id, "Task fulfill: task not found");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
             let value_headers_json = action_data
                 .value
                 .headers
@@ -1691,7 +1729,16 @@ async fn op_task_fence(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> 
             let action_id = action_data["id"].as_str().unwrap_or("");
             db.try_timeout(&[&r.id, action_id], now)?;
             // Lock preamble: ensures fence check sees current task state.
-            let _ = db.lock_for_update(&r.id)?;
+            let (_, task_exists) = db.lock_for_update(&r.id)?;
+            if !task_exists {
+                tracing::debug!(task_id = %r.id, "Task fence: task not found");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
 
             match action_kind.as_str() {
                 "promise.create" => {
@@ -2005,6 +2052,16 @@ async fn op_task_halt(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> R
                 ));
             }
             db.try_timeout(&[&r.id], now)?;
+            let (_, task_exists) = db.lock_for_update(&r.id)?;
+            if !task_exists {
+                tracing::debug!(task_id = %r.id, "Task halt: not found");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
             let result = db.task_halt(&r.id)?;
             if !result.task_exists {
                 tracing::debug!(task_id = %r.id, "Task halt: not found");
@@ -2075,6 +2132,16 @@ async fn op_task_continue(
                 ));
             }
             db.try_timeout(&[&r.id], now)?;
+            let (_, task_exists) = db.lock_for_update(&r.id)?;
+            if !task_exists {
+                tracing::debug!(task_id = %r.id, "Task continue: not found");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
             let result = db.task_continue(&r.id, now)?;
             match result.state {
                 None => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1150,7 +1150,7 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                 .headers
                 .as_ref()
                 .map(|h| serde_json::to_string(h).unwrap());
-            let result = db.task_create(&TaskCreateParams {
+            let res = db.task_create(&TaskCreateParams {
                 promise_id: action_id,
                 state: p_state.as_str(),
                 param_headers: param_headers_json.as_deref(),
@@ -1163,16 +1163,6 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                 ttl: r.ttl,
                 pid: &r.pid,
             })?;
-            if result.is_none() {
-                tracing::debug!(task_id = %action_id, "Task create: underlying promise not found");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Promise not found",
-                ));
-            }
-            let res = result.unwrap();
 
             // If the promise is settled, process callbacks as a separate
             // statement. This fires any callbacks registered by concurrent
@@ -1213,105 +1203,84 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
             }
 
             // CTE didn't create the task (promise already existed).
-            // Statement 2: try to acquire as a SEPARATE statement —
-            // gets a fresh READ COMMITTED snapshot that sees all
-            // concurrent commits (e.g. task.release making it pending).
-            let acquire_result = db.task_acquire(&TaskAcquireParams {
-                task_id: action_id,
-                version: 0,
-                time: now,
-                ttl: r.ttl,
-                pid: &r.pid,
-            })?;
-            if !acquire_result.was_acquired {
-                // Acquire with version 0 failed. Read current state
-                // (fresh snapshot) and retry with actual version.
-                let task = db.task_get(action_id)?;
-                match &task {
-                    None => {
-                        return Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            422,
-                            "Promise exists without a target task",
-                        ));
-                    }
-                    Some(t) if t.state == TaskState::Fulfilled => {
-                        return Ok(ResponseEnvelope::success(
+            // task_state and task_version come directly from the CTE result.
+            match (res.task_state.as_deref(), res.task_version) {
+                (Some("fulfilled"), version) => {
+                    // Transition #14: already fulfilled — idempotent success.
+                    Ok(ResponseEnvelope::success(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        &TaskCreateResponseData {
+                            task: TaskRecord {
+                                id: action_id.to_string(),
+                                state: TaskState::Fulfilled,
+                                version: version.unwrap_or(0),
+                                resumes: 0,
+                                ttl: None,
+                                pid: None,
+                            },
+                            promise: res.promise,
+                            preload: vec![],
+                        },
+                    ))
+                }
+                (Some("pending"), Some(version)) => {
+                    // Transition #16: pending with correct version — try to acquire.
+                    let acquire_result = db.task_acquire(&TaskAcquireParams {
+                        task_id: action_id,
+                        version,
+                        time: now,
+                        ttl: r.ttl,
+                        pid: &r.pid,
+                    })?;
+                    if acquire_result.was_acquired {
+                        let task = TaskRecord {
+                            id: action_id.to_string(),
+                            state: TaskState::Acquired,
+                            version: version + 1,
+                            resumes: 0,
+                            ttl: Some(r.ttl),
+                            pid: Some(r.pid.to_string()),
+                        };
+                        let preload = db.compute_preload(action_id)?;
+                        Ok(ResponseEnvelope::success(
                             kind_str.clone(),
                             corr_id.clone(),
                             &TaskCreateResponseData {
-                                task: t.clone(),
+                                task,
                                 promise: res.promise,
-                                preload: vec![],
+                                preload,
                             },
-                        ));
-                    }
-                    Some(t) if t.state == TaskState::Pending => {
-                        let retry = db.task_acquire(&TaskAcquireParams {
-                            task_id: action_id,
-                            version: t.version,
-                            time: now,
-                            ttl: r.ttl,
-                            pid: &r.pid,
-                        })?;
-                        if retry.was_acquired {
-                            let task = TaskRecord {
-                                id: action_id.to_string(),
-                                state: TaskState::Acquired,
-                                version: t.version + 1,
-                                resumes: 0,
-                                ttl: Some(r.ttl),
-                                pid: Some(r.pid.to_string()),
-                            };
-                            let preload = db.compute_preload(action_id)?;
-                            return Ok(ResponseEnvelope::success(
-                                kind_str.clone(),
-                                corr_id.clone(),
-                                &TaskCreateResponseData {
-                                    task,
-                                    promise: res.promise,
-                                    preload,
-                                },
-                            ));
-                        }
-                        return Ok(ResponseEnvelope::error(
+                        ))
+                    } else {
+                        // Transition #17: version raced — another caller acquired first.
+                        Ok(ResponseEnvelope::error(
                             kind_str.clone(),
                             corr_id.clone(),
                             409,
                             "Already exists",
-                        ));
-                    }
-                    _ => {
-                        return Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            409,
-                            "Already exists",
-                        ));
+                        ))
                     }
                 }
+                (None, _) => {
+                    // Transition #9: promise exists but has no target task (no address).
+                    Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        422,
+                        "Promise exists without a target task",
+                    ))
+                }
+                _ => {
+                    // Transitions #11–#13: acquired / suspended / halted.
+                    Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        409,
+                        "Already exists",
+                    ))
+                }
             }
-
-            // Acquired with version 1 (first claim)
-            let task = TaskRecord {
-                id: action_id.to_string(),
-                state: TaskState::Acquired,
-                version: 1,
-                resumes: 0,
-                ttl: Some(r.ttl),
-                pid: Some(r.pid.to_string()),
-            };
-            let preload = db.compute_preload(action_id)?;
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &TaskCreateResponseData {
-                    task,
-                    promise: res.promise,
-                    preload,
-                },
-            ))
         })
         .await
     {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1196,7 +1196,11 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                     ttl: if task_state == TaskState::Fulfilled { None } else { Some(r.ttl) },
                     pid: if task_state == TaskState::Fulfilled { None } else { Some(r.pid.to_string()) },
                 };
-                let preload = db.compute_preload(action_id)?;
+                let preload = if task_state == TaskState::Acquired {
+                    db.compute_preload(action_id)?
+                } else {
+                    vec![]
+                };
                 return Ok(ResponseEnvelope::success(
                     kind_str.clone(),
                     corr_id.clone(),
@@ -1233,14 +1237,13 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                         ));
                     }
                     Some(t) if t.state == TaskState::Fulfilled => {
-                        let preload = db.compute_preload(action_id)?;
                         return Ok(ResponseEnvelope::success(
                             kind_str.clone(),
                             corr_id.clone(),
                             &TaskCreateResponseData {
                                 task: t.clone(),
                                 promise: res.promise,
-                                preload,
+                                preload: vec![],
                             },
                         ));
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1165,12 +1165,10 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                 db.process_callbacks(action_id, now)?;
             }
 
-            // When the CTE created the task, use CTE result directly.
             if res.task_created {
                 let task_state_str = res.task_state.unwrap_or_default();
                 let task_state = task_state_str.parse::<TaskState>().unwrap_or(TaskState::Acquired);
-                // Acquired tasks start at version 1 (first claim), fulfilled at 0
-                let task_version = if task_state == TaskState::Acquired { 1 } else { 0 };
+                let task_version = res.task_version.unwrap_or(0);
                 let task = TaskRecord {
                     id: action_id.to_string(),
                     state: task_state,
@@ -1257,6 +1255,11 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                 }
                 (None, _) => {
                     // Transition #9: promise exists but has no target task (no address).
+                    assert!(
+                        !res.promise.tags.contains_key("resonate:target"),
+                        "promise {} has resonate:target but no task row",
+                        action_id
+                    );
                     Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
@@ -1333,53 +1336,17 @@ async fn op_task_acquire(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                 }
                 Some(promise) => {
                     if !result.was_acquired {
-                        let task = db.task_get(&r.id)?;
-                        if let Some(t) = task {
-                            if t.state != TaskState::Pending {
-                                tracing::debug!(
-                                    task_id = %r.id,
-                                    current_state = %t.state,
-                                    "Task acquire rejected: not pending"
-                                );
-                                return Ok(ResponseEnvelope::error(
-                                    kind_str.clone(),
-                                    corr_id.clone(),
-                                    409,
-                                    "Task is not pending",
-                                ));
-                            }
-                            if t.version != r.version {
-                                tracing::debug!(
-                                    task_id = %r.id,
-                                    expected_version = r.version,
-                                    actual_version = t.version,
-                                    "Task acquire rejected: version mismatch"
-                                );
-                                return Ok(ResponseEnvelope::error(
-                                    kind_str.clone(),
-                                    corr_id.clone(),
-                                    409,
-                                    "Version mismatch",
-                                ));
-                            }
-                        }
-                        tracing::debug!(
-                            task_id = %r.id,
-                            "Task acquire rejected: could not acquire (concurrent modification)"
-                        );
                         return Ok(ResponseEnvelope::error(
                             kind_str.clone(),
                             corr_id.clone(),
                             409,
-                            "Task is not pending",
+                            "Task could not be acquired",
                         ));
                     }
-                    // Use known values — no separate task_get that could
-                    // see stale state from concurrent transactions.
                     let task = TaskRecord {
                         id: r.id.to_string(),
-                        state: TaskState::Acquired,
-                        version: r.version + 1,
+                        state: result.task_state.unwrap(),
+                        version: result.task_version.unwrap(),
                         resumes: 0,
                         ttl: Some(r.ttl),
                         pid: Some(r.pid.to_string()),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1557,16 +1557,7 @@ async fn op_task_fulfill(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                         &TaskFulfillResponseData { promise },
                     ))
                 }
-                None => {
-                    // TODO this is just wrong
-                    tracing::warn!(task_id = %r.id, "Task fulfilled but promise not found");
-                    Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Promise not found",
-                    ))
-                }
+                None => unreachable!("task exists implies promise exists"),
             }
         })
         .await

--- a/src/server.rs
+++ b/src/server.rs
@@ -614,7 +614,7 @@ async fn op_promise_create(
                 .headers
                 .as_ref()
                 .map(|h| serde_json::to_string(h).unwrap());
-            let promise = db.promise_create(&PromiseCreateParams {
+            let result = db.promise_create(&PromiseCreateParams {
                 id: &r.id,
                 state: state.as_str(),
                 param_headers: param_headers_json.as_deref(),
@@ -626,27 +626,26 @@ async fn op_promise_create(
                 already_timedout,
                 address,
             })?;
-            let is_new = promise.created_at == created_at;
-            if is_new {
+            if result.was_created {
                 tracing::info!(
-                    promise_id = %promise.id,
-                    state = %promise.state,
-                    timeout_at = promise.timeout_at,
+                    promise_id = %result.promise.id,
+                    state = %result.promise.state,
+                    timeout_at = result.promise.timeout_at,
                     target = address.unwrap_or("none"),
                     already_timedout = already_timedout,
                     "Promise created"
                 );
             } else {
                 tracing::debug!(
-                    promise_id = %promise.id,
-                    state = %promise.state,
+                    promise_id = %result.promise.id,
+                    state = %result.promise.state,
                     "Promise create: already exists (idempotent)"
                 );
             }
             Ok(ResponseEnvelope::success(
                 kind_str.clone(),
                 corr_id.clone(),
-                &PromiseResponseData { promise },
+                &PromiseResponseData { promise: result.promise },
             ))
         })
         .await
@@ -706,14 +705,8 @@ async fn op_promise_settle(
             })?;
             match result.promise {
                 Some(promise) => {
-                    if !result.was_settled && promise.state == PromiseState::Pending {
-                        tracing::debug!(promise_id = %r.id, "Promise settle: TOCTOU race detected, treating as not found");
-                        return Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            404,
-                            "Promise not found",
-                        ));
+                    if promise.state == PromiseState::Pending {
+                        unreachable!("promise settle returned pending promise without settling");
                     }
                     if result.was_settled {
                         tracing::info!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -1403,61 +1403,31 @@ async fn op_task_release(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                 ));
             }
             db.try_timeout(&[&r.id], now)?;
-            let task = match db.task_get(&r.id)? {
-                Some(t) => t,
-                None => {
-                    tracing::debug!(task_id = %r.id, "Task release: task not found");
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Task not found",
-                    ))
-                }
-            };
-            if task.state != TaskState::Acquired {
-                tracing::debug!(
-                    task_id = %r.id,
-                    current_state = %task.state,
-                    "Task release rejected: task is not acquired"
-                );
+            let result = db.task_release(&r.id, r.version, now, db.task_retry_timeout())?;
+            if result.task_released {
+                tracing::info!(task_id = %r.id, version = r.version, "Task released back to pending");
+                return Ok(ResponseEnvelope::new(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    200,
+                    serde_json::json!({}),
+                ));
+            }
+            if !result.task_exists {
+                tracing::debug!(task_id = %r.id, "Task release: task not found");
                 return Ok(ResponseEnvelope::error(
                     kind_str.clone(),
                     corr_id.clone(),
-                    409,
-                    "Task is not acquired",
+                    404,
+                    "Task not found",
                 ));
             }
-            if task.version != r.version {
-                tracing::debug!(
-                    task_id = %r.id,
-                    expected_version = r.version,
-                    actual_version = task.version,
-                    "Task release rejected: version mismatch"
-                );
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Version mismatch",
-                ));
-            }
-            let released = db.task_release(&r.id, r.version, now, db.task_retry_timeout())?;
-            if !released {
-                tracing::debug!(task_id = %r.id, version = r.version, "Task release rejected: version mismatch or invalid state");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Task version mismatch or invalid state",
-                ));
-            }
-            tracing::info!(task_id = %r.id, version = r.version, "Task released back to pending");
-            Ok(ResponseEnvelope::new(
+            tracing::debug!(task_id = %r.id, version = r.version, "Task release rejected: version mismatch or invalid state");
+            Ok(ResponseEnvelope::error(
                 kind_str.clone(),
                 corr_id.clone(),
-                200,
-                serde_json::json!({}),
+                409,
+                "Task version mismatch or invalid state",
             ))
         })
         .await
@@ -1503,45 +1473,6 @@ async fn op_task_fulfill(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
             // Lock preamble: lock promise + task to prevent stale snapshot
             // in precondition check and fulfillment CTE.
             let _ = db.lock_for_update(&r.id)?;
-            let task = match db.task_get(&r.id)? {
-                Some(t) => t,
-                None => {
-                    tracing::debug!(task_id = %r.id, "Task fulfill: task not found");
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Task not found",
-                    ))
-                }
-            };
-            if task.state != TaskState::Acquired {
-                tracing::debug!(
-                    task_id = %r.id,
-                    current_state = %task.state,
-                    "Task fulfill rejected: task is not acquired"
-                );
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Task is not acquired",
-                ));
-            }
-            if task.version != r.version {
-                tracing::debug!(
-                    task_id = %r.id,
-                    expected_version = r.version,
-                    actual_version = task.version,
-                    "Task fulfill rejected: version mismatch"
-                );
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Version mismatch",
-                ));
-            }
             let value_headers_json = action_data
                 .value
                 .headers
@@ -1556,6 +1487,15 @@ async fn op_task_fulfill(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                 value_data: action_data.value.data.as_deref(),
                 settled_at: now,
             })?;
+            if !result.task_exists {
+                tracing::debug!(task_id = %r.id, "Task fulfill: task not found");
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
             if !result.task_fulfilled {
                 tracing::debug!(task_id = %r.id, version = r.version, "Task fulfill rejected: version mismatch or invalid state");
                 return Ok(ResponseEnvelope::error(
@@ -1580,6 +1520,7 @@ async fn op_task_fulfill(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                     ))
                 }
                 None => {
+                    // TODO this is just wrong
                     tracing::warn!(task_id = %r.id, "Task fulfilled but promise not found");
                     Ok(ResponseEnvelope::error(
                         kind_str.clone(),
@@ -1637,6 +1578,14 @@ async fn op_task_suspend(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
             // Lock the task row BEFORE try_timeout to prevent
             // try_timeout from fulfilling it via promise timeout.
             let (_, task_exists) = db.lock_for_update(&r.id)?;
+            if !task_exists {
+                return Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ));
+            }
             db.try_timeout(&timeout_ids, now)?;
             let mut seen = std::collections::HashSet::new();
             let unique_awaited: Vec<&str> = awaited_ids
@@ -1646,16 +1595,6 @@ async fn op_task_suspend(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                 .collect();
             let result = db.task_suspend(&r.id, r.version, &unique_awaited)?;
             if !result.task_matched {
-                // Use lock_for_update result — no separate task_get that
-                // could see a concurrent task creation.
-                if !task_exists {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Task not found",
-                    ));
-                }
                 tracing::debug!(
                     task_id = %r.id,
                     version = r.version,


### PR DESCRIPTION
## Summary

A series of targeted cleanups to the persistence layer and server to reduce unnecessary DB round-trips, eliminate dead code, and tighten invariants:

- **Eliminate pre-flight `task_get` calls**: surface `task_exists`, state, and version directly from `acquire`/`create`/`release`/`fulfill` results so callers don't need a separate lookup.
- **Consolidate task queries**: use task state (instead of `timeout_type`) to gate `ttl`/`pid` fields; consolidate lease timeout into a CTE in `task.create`; remove the `Option` return type.
- **Skip unnecessary work**: avoid `compute_preload` for already-fulfilled tasks in `task.create`; return early via `lock_for_update task_exists` for missing tasks.
- **Replace dead code with `unreachable!`**: task existence guarantees promise existence, so fallback branches can be removed in favor of explicit invariant assertions. Same for `promise_create` empty-rows fallback.
- **Surface `was_created` explicitly**: add `PromiseCreateResult` to make the flag part of the type instead of inferring it from row counts.

Net result: ~370 lines removed, cleaner invariants, fewer DB queries per operation.