### PR TITLE
remove stale branches

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,0 +1,18 @@
+name: Remove Stale Branches
+
+permissions:
+  contents: write
+  actions: read
+  pull-requests: read
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Everday at midnight
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: Remove Stale Branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@v2.4.0


### PR DESCRIPTION
This configuration will mark all branches (except for main/master) as stale after 90 days. After 7 more days, it will remove the branch.

https://github.com/marketplace/actions/remove-stale-branches
