### PR TITLE
fix: simplify task_continue query to use existence checks

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -111,7 +111,7 @@ pub struct TaskHaltResult {
 }
 
 pub struct TaskContinueResult {
-    pub state: Option<TaskState>,
+    pub task_exists: bool,
     pub continued: bool,
 }
 

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -1564,7 +1564,7 @@ impl Db for PostgresDb<'_> {
             continued_task AS (
               UPDATE tasks SET state = 'pending'
               WHERE id = $1 AND state = 'halted'
-              RETURNING *
+              RETURNING id, version
             ),
             inserted_ttimeout AS (
               INSERT INTO task_timeouts (timeout_at, id, timeout_type, ttl)
@@ -1580,25 +1580,20 @@ impl Db for PostgresDb<'_> {
               ON CONFLICT (id) DO UPDATE SET version = EXCLUDED.version, address = EXCLUDED.address
               RETURNING id
             )
-            SELECT t.state, EXISTS (SELECT 1 FROM continued_task) AS continued
-            FROM tasks t WHERE t.id = $1
+            SELECT
+              EXISTS (SELECT 1 FROM locked_task) AS task_exists,
+              EXISTS (SELECT 1 FROM continued_task) AS continued
         "
             ))
             .bind(task_id)
             .bind(time)
-            .fetch_optional(self.tx().as_mut()),
+            .fetch_one(self.tx().as_mut()),
         )?;
 
-        match row {
-            Some(r) => Ok(TaskContinueResult {
-                state: Some(parse_task_state(&r.get::<String, _>("state"))),
-                continued: r.get("continued"),
-            }),
-            None => Ok(TaskContinueResult {
-                state: None,
-                continued: false,
-            }),
-        }
+        Ok(TaskContinueResult {
+            task_exists: row.get::<bool, _>("task_exists"),
+            continued: row.get::<bool, _>("continued"),
+        })
     }
 
     // T-11: task.search — single query with resumes subquery

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -1122,16 +1122,15 @@ impl<'a> Db for SqliteDb<'a> {
             }
         }
 
-        match self.task_get(task_id)? {
-            Some(t) => Ok(TaskContinueResult {
-                state: Some(t.state),
-                continued,
-            }),
-            None => Ok(TaskContinueResult {
-                state: None,
-                continued: false,
-            }),
-        }
+        let task_exists: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM tasks WHERE id = ?1)",
+            params![task_id],
+            |r| r.get(0),
+        )?;
+        Ok(TaskContinueResult {
+            task_exists,
+            continued,
+        })
     }
 
     fn task_search(

--- a/src/server.rs
+++ b/src/server.rs
@@ -2136,35 +2136,30 @@ async fn op_task_continue(
             }
             db.try_timeout(&[&r.id], now)?;
             let result = db.task_continue(&r.id, now)?;
-            match result.state {
-                None => {
-                    tracing::debug!(task_id = %r.id, "Task continue: not found");
-                    Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Task not found",
-                    ))
-                }
-                Some(_state) => {
-                    if result.continued {
-                        tracing::info!(task_id = %r.id, "Task continued from halted state");
-                        Ok(ResponseEnvelope::new(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            200,
-                            serde_json::json!({}),
-                        ))
-                    } else {
-                        tracing::debug!(task_id = %r.id, "Task continue rejected: not halted");
-                        Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            409,
-                            "Task is not halted",
-                        ))
-                    }
-                }
+            if !result.task_exists {
+                tracing::debug!(task_id = %r.id, "Task continue: not found");
+                Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    404,
+                    "Task not found",
+                ))
+            } else if result.continued {
+                tracing::info!(task_id = %r.id, "Task continued from halted state");
+                Ok(ResponseEnvelope::new(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    200,
+                    serde_json::json!({}),
+                ))
+            } else {
+                tracing::debug!(task_id = %r.id, "Task continue rejected: not halted");
+                Ok(ResponseEnvelope::error(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    409,
+                    "Task is not halted",
+                ))
             }
         })
         .await


### PR DESCRIPTION
Replace state-based result with boolean task_exists flag, avoiding an extra task lookup and making the postgres query always return a row.