### PR TITLE
feat: add CORS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,4 @@ validator = { version = "0.18", features = ["derive"] }
 url = "2"
 base64 = "0.22"
 google-cloud-pubsub = "0.33.1"
-tower-http = { version = "0.6", features = ["trace", "catch-panic"] }
+tower-http = { version = "0.6", features = ["trace", "catch-panic", "cors"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,11 @@ pub struct CommonArgs {
     #[arg(long = "server-url", value_name = "URL")]
     pub url: Option<String>,
 
+    // --- CORS ---
+    /// Allowed CORS origins (repeatable; use "*" for permissive access)
+    #[arg(long = "server-cors-allow-origin", value_name = "ORIGIN")]
+    pub cors_allow_origins: Vec<String>,
+
     // --- Storage ---
     /// Storage backend: sqlite or postgres [default: sqlite]
     #[arg(long = "storage-type")]
@@ -158,6 +163,10 @@ impl CommonArgs {
                 "http://{}:{}",
                 config.server.host, config.server.port
             ));
+        }
+
+        if !self.cors_allow_origins.is_empty() {
+            config.server.cors.allow_origins = self.cors_allow_origins;
         }
 
         if let Some(v) = self.storage_type {

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,21 @@ fn default_level() -> String {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorsConfig {
+    /// Allowed origins. Empty = CORS disabled. Use ["*"] for permissive access.
+    #[serde(default)]
+    pub allow_origins: Vec<String>,
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self {
+            allow_origins: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
     /// HTTP server host
     #[serde(default = "default_host")]
@@ -82,6 +97,10 @@ pub struct ServerConfig {
     /// Defaults to http://{host}:{port} if not set.
     #[serde(default)]
     pub url: Option<String>,
+
+    /// CORS configuration
+    #[serde(default)]
+    pub cors: CorsConfig,
 }
 
 fn default_host() -> String {
@@ -105,6 +124,7 @@ impl Default for ServerConfig {
             bind: default_bind(),
             shutdown_timeout: default_shutdown_timeout(),
             url: None,
+            cors: CorsConfig::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,19 +60,11 @@ fn default_level() -> String {
     "info".to_string()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CorsConfig {
     /// Allowed origins. Empty = CORS disabled. Use ["*"] for permissive access.
     #[serde(default)]
     pub allow_origins: Vec<String>,
-}
-
-impl Default for CorsConfig {
-    fn default() -> Self {
-        Self {
-            allow_origins: vec![],
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,15 @@ mod util;
 
 use std::sync::Arc;
 
-use axum::{http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use axum::{
+    http::{
+        header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, ORIGIN},
+        HeaderValue, Method, StatusCode,
+    },
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
 use clap::{Parser, Subcommand};
 use config::Config;
 use persistence::{persistence_sqlite::SqliteStorage, Storage};
@@ -282,12 +290,21 @@ async fn run_server(config: Config) -> Result<(), String> {
     // Build HTTP router
     let effective_url = state.config.server.url.clone().unwrap_or_default();
     let (sse_shutdown_tx, sse_shutdown_rx) = tokio::sync::watch::channel(false);
+
+    let cors_layer = build_cors_layer(&state.config.server.cors.allow_origins);
+    if !state.config.server.cors.allow_origins.is_empty() {
+        tracing::info!(
+            origins = ?state.config.server.cors.allow_origins,
+            "CORS enabled"
+        );
+    }
+
     let app_state = server::AppState {
         server: state,
         poll_registry,
         sse_shutdown_rx,
     };
-    let app = server::api_routes()
+    let mut app = server::api_routes()
         .merge(server::poll_routes())
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(
             handle_panic,
@@ -305,6 +322,10 @@ async fn run_server(config: Config) -> Result<(), String> {
                 ),
         )
         .with_state(app_state);
+    if let Some(layer) = cors_layer {
+        app = app.layer(layer);
+    }
+    let app = app;
     let listener = tokio::net::TcpListener::bind(format!("{}:{}", bind, port))
         .await
         .map_err(|e| format!("Failed to bind to {}:{}: {e}", bind, port))?;
@@ -335,6 +356,32 @@ async fn run_server(config: Config) -> Result<(), String> {
 
     tracing::info!("Resonate Server stopped");
     Ok(())
+}
+
+fn build_cors_layer(allow_origins: &[String]) -> Option<tower_http::cors::CorsLayer> {
+    if allow_origins.is_empty() {
+        return None;
+    }
+    let layer = if allow_origins.iter().any(|o| o == "*") {
+        tower_http::cors::CorsLayer::permissive()
+    } else {
+        let origins: Vec<HeaderValue> = allow_origins
+            .iter()
+            .filter_map(|o| o.parse().ok())
+            .collect();
+        tower_http::cors::CorsLayer::new()
+            .allow_origin(origins)
+            .allow_methods([
+                Method::GET,
+                Method::POST,
+                Method::PUT,
+                Method::PATCH,
+                Method::DELETE,
+                Method::OPTIONS,
+            ])
+            .allow_headers([ORIGIN, CONTENT_LENGTH, CONTENT_TYPE, AUTHORIZATION])
+    };
+    Some(layer)
 }
 
 fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {


### PR DESCRIPTION
## Summary

Ports the CORS feature from the legacy Go server to the new Rust server.

Browser-based clients (SDKs, dashboards, agent UIs) require CORS headers to make cross-origin requests. The legacy server supported this via `gin-contrib/cors` on the HTTP API and manual header injection on the poll/SSE endpoint. The new server serves both on the same Axum router, so a single `tower-http` `CorsLayer` applied at the top level covers both endpoints.

## Changes

- **`Cargo.toml`** — enables the `cors` feature on `tower-http`
- **`src/config.rs`** — adds `CorsConfig { allow_origins: Vec<String> }` nested under `ServerConfig`; defaults to empty list (CORS disabled)
- **`src/cli.rs`** — adds `--server-cors-allow-origin <ORIGIN>` flag (repeatable); wires it into `config.server.cors.allow_origins`
- **`src/main.rs`** — adds `build_cors_layer()` and applies the resulting `Option<CorsLayer>` to the router

## Behaviour

| Configuration | Result |
|---|---|
| `allow_origins` empty (default) | No CORS headers added — existing behaviour preserved |
| `allow_origins = ["*"]` | `CorsLayer::permissive()` — unrestricted access |
| Specific origins list | Reflects request `Origin` only when it matches — CORS spec compliant |

Preflight `OPTIONS` requests are handled automatically by `tower-http`.

Allowed methods: `GET, POST, PUT, PATCH, DELETE, OPTIONS`  
Allowed headers: `Origin, Content-Length, Content-Type, Authorization`

## Configuration

All three surfaces are supported, consistent with every other config key in this project:

```toml
# resonate.toml
[server.cors]
allow_origins = ["https://app.example.com"]
```

```sh
# Environment variable
RESONATE_SERVER__CORS__ALLOW_ORIGINS=https://app.example.com

# CLI flag (repeatable)
resonate serve --server-cors-allow-origin https://app.example.com --server-cors-allow-origin https://other.example.com

# Wildcard
RESONATE_SERVER__CORS__ALLOW_ORIGINS=*
resonate serve --server-cors-allow-origin '*'
```

## Difference from legacy server

The legacy server had **two independent CORS configs** — one for the HTTP API and one for the poll/SSE plugin — each requiring a separate flag (`--api-cors-allow-origin`, `--poll-cors-allow-origin`). Because the new server merges both into a single Axum router, one config covers both, simplifying the surface.

The only behavioural difference: when `"*"` is configured, `CorsLayer::permissive()` also sets `Allow-Credentials: true`, whereas the legacy server did not. This is strictly more permissive, not less.

Closes resonatehq/resonate#1080