### PR TITLE
feat: add per-transport enable/disable flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,6 +106,10 @@ pub struct CommonArgs {
     pub messages_batch_size: Option<i64>,
 
     // --- HTTP Push ---
+    /// Enable/disable HTTP push transport [default: true]
+    #[arg(long = "transports-http-push-enabled", value_name = "BOOL")]
+    pub transports_http_push_enabled: Option<bool>,
+
     /// Max concurrent HTTP push deliveries [default: 16]
     #[arg(long = "transports-http-push-concurrency", value_name = "N")]
     pub transports_http_push_concurrency: Option<usize>,
@@ -119,6 +123,10 @@ pub struct CommonArgs {
     pub transports_http_push_request_timeout: Option<u64>,
 
     // --- HTTP Poll/SSE ---
+    /// Enable/disable HTTP poll (SSE) transport [default: true]
+    #[arg(long = "transports-http-poll-enabled", value_name = "BOOL")]
+    pub transports_http_poll_enabled: Option<bool>,
+
     /// Max concurrent poll (SSE) connections [default: 1000]
     #[arg(long = "transports-http-poll-max-connections", value_name = "N")]
     pub transports_http_poll_max_connections: Option<usize>,
@@ -128,9 +136,18 @@ pub struct CommonArgs {
     pub transports_http_poll_buffer_size: Option<usize>,
 
     // --- GCP Pub/Sub ---
-    /// GCP project ID (enables GCP Pub/Sub transport)
+    /// Enable/disable GCP Pub/Sub transport [default: false]
+    #[arg(long = "transports-gcps-enabled", value_name = "BOOL")]
+    pub transports_gcps_enabled: Option<bool>,
+
+    /// GCP project ID
     #[arg(long = "transports-gcps-project", value_name = "PROJECT")]
     pub transports_gcps_project: Option<String>,
+
+    // --- Bash Exec ---
+    /// Enable/disable bash exec transport [default: false]
+    #[arg(long = "transports-bash-exec-enabled", value_name = "BOOL")]
+    pub transports_bash_exec_enabled: Option<bool>,
 
     // --- Observability ---
     /// Prometheus metrics port (0 = disabled) [default: 9090]
@@ -232,6 +249,9 @@ impl CommonArgs {
             config.messages.batch_size = v;
         }
 
+        if let Some(v) = self.transports_http_push_enabled {
+            config.transports.http_push.enabled = v;
+        }
         if let Some(v) = self.transports_http_push_concurrency {
             config.transports.http_push.concurrency = v;
         }
@@ -242,6 +262,9 @@ impl CommonArgs {
             config.transports.http_push.request_timeout = v;
         }
 
+        if let Some(v) = self.transports_http_poll_enabled {
+            config.transports.http_poll.enabled = v;
+        }
         if let Some(v) = self.transports_http_poll_max_connections {
             config.transports.http_poll.max_connections = v;
         }
@@ -249,12 +272,15 @@ impl CommonArgs {
             config.transports.http_poll.buffer_size = v;
         }
 
+        if let Some(v) = self.transports_gcps_enabled {
+            config.transports.gcps.enabled = v;
+        }
         if let Some(project) = self.transports_gcps_project {
-            let gcps = config
-                .transports
-                .gcps
-                .get_or_insert(crate::config::GcpsConfig { project: None });
-            gcps.project = Some(project);
+            config.transports.gcps.project = Some(project);
+        }
+
+        if let Some(v) = self.transports_bash_exec_enabled {
+            config.transports.bash_exec.enabled = v;
         }
 
         if let Some(v) = self.observability_metrics_port {

--- a/src/config.rs
+++ b/src/config.rs
@@ -320,20 +320,20 @@ pub struct TransportsConfig {
 
     /// Google Cloud Pub/Sub transport configuration
     #[serde(default)]
-    pub gcps: Option<GcpsConfig>,
+    pub gcps: GcpsConfig,
 
     /// Bash execution transport configuration
     #[serde(default)]
-    pub bash_exec: Option<BashExecConfig>,
+    pub bash_exec: BashExecConfig,
 }
 
 /// Bash execution transport configuration.
-///
-/// When present, enables the bash:// address scheme.
-/// Inline scripts (bash://) are read from param.data.
-/// Named scripts (bash:///relative/path.sh) are resolved relative to root_dir.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BashExecConfig {
+    /// Enable the bash:// address scheme [default: false]
+    #[serde(default)]
+    pub enabled: bool,
+
     /// Root directory for named scripts (bash:///relative/path.sh).
     /// Not required if only inline scripts are used.
     #[serde(default)]
@@ -351,19 +351,39 @@ fn default_working_dir() -> String {
     "<root>".to_string()
 }
 
+impl Default for BashExecConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            root_dir: None,
+            working_dir: default_working_dir(),
+        }
+    }
+}
+
 /// Google Cloud Pub/Sub transport configuration.
-///
-/// When present, enables the gcps:// address scheme.
 /// Authentication uses Application Default Credentials (ADC).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GcpsConfig {
+    /// Enable the gcps:// address scheme [default: false]
+    #[serde(default)]
+    pub enabled: bool,
+
     /// Default GCP project ID. Used when the address doesn't specify a project.
     #[serde(default)]
     pub project: Option<String>,
 }
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HttpPushConfig {
+    /// Enable the http:// / https:// address scheme [default: true]
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
     /// Max concurrent HTTP push deliveries
     #[serde(default = "default_http_push_concurrency")]
     pub concurrency: usize,
@@ -390,6 +410,7 @@ fn default_http_push_request_timeout() -> u64 {
 impl Default for HttpPushConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             concurrency: default_http_push_concurrency(),
             connect_timeout: default_http_push_connect_timeout(),
             request_timeout: default_http_push_request_timeout(),
@@ -399,6 +420,10 @@ impl Default for HttpPushConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HttpPollConfig {
+    /// Enable the poll:// (SSE) address scheme [default: true]
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
     /// Maximum number of concurrent poll (SSE) connections
     #[serde(default = "default_http_poll_max_connections")]
     pub max_connections: usize,
@@ -418,6 +443,7 @@ fn default_http_poll_buffer_size() -> usize {
 impl Default for HttpPollConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             max_connections: default_http_poll_max_connections(),
             buffer_size: default_http_poll_buffer_size(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use config::Config;
 use persistence::{persistence_mysql::MysqlStorage, persistence_sqlite::SqliteStorage, Storage};
 use server::Server;
 use transport::transport_http_poll::PollRegistry;
+use transport::{BashTransport, GcpsTransport, HttpTransport, PollTransport};
 use types::ResponseEnvelope;
 
 #[derive(Parser)]
@@ -238,44 +239,53 @@ async fn run_server(config: Config) -> Result<(), String> {
         "Transport config"
     );
     let poll_registry = Arc::new(PollRegistry::new(poll_max_connections, poll_buffer_size));
-    let http_push = Arc::new(transport::transport_http_push::HttpPushTransport::new(
-        std::time::Duration::from_millis(state.config.transports.http_push.connect_timeout),
-        std::time::Duration::from_millis(state.config.transports.http_push.request_timeout),
-    ));
-    let gcps = match &state.config.transports.gcps {
-        Some(_gcps_config) => {
-            tracing::info!("GCP Pub/Sub transport enabled");
-            Some(Arc::new(
-                transport::transport_gcps::GcpsPubSubTransport::new(),
-            ))
-        }
-        None => None,
+    let http_push: Option<Arc<dyn HttpTransport>> = if state.config.transports.http_push.enabled {
+        Some(Arc::new(
+            transport::transport_http_push::HttpPushTransport::new(
+                std::time::Duration::from_millis(state.config.transports.http_push.connect_timeout),
+                std::time::Duration::from_millis(state.config.transports.http_push.request_timeout),
+            ),
+        ))
+    } else {
+        tracing::info!("HTTP push transport disabled");
+        None
     };
-    let bash = match &state.config.transports.bash_exec {
-        Some(bash_cfg) => {
-            match &bash_cfg.root_dir {
-                Some(dir) => {
-                    tracing::info!(root_dir = %dir, working_dir = %bash_cfg.working_dir, "Bash exec transport enabled")
-                }
-                None => tracing::info!("Bash exec transport enabled (inline only)"),
+    let http_poll: Option<Arc<dyn PollTransport>> = if state.config.transports.http_poll.enabled {
+        Some(poll_registry.clone())
+    } else {
+        tracing::info!("HTTP poll transport disabled");
+        None
+    };
+    let gcps: Option<Arc<dyn GcpsTransport>> = if state.config.transports.gcps.enabled {
+        tracing::info!("GCP Pub/Sub transport enabled");
+        Some(Arc::new(
+            transport::transport_gcps::GcpsPubSubTransport::new(),
+        ))
+    } else {
+        None
+    };
+    let bash: Option<Arc<dyn BashTransport>> = if state.config.transports.bash_exec.enabled {
+        let bash_cfg = &state.config.transports.bash_exec;
+        match &bash_cfg.root_dir {
+            Some(dir) => {
+                tracing::info!(root_dir = %dir, working_dir = %bash_cfg.working_dir, "Bash exec transport enabled")
             }
-            let working_dir =
-                transport::transport_exec_bash::WorkingDir::from_config(&bash_cfg.working_dir);
-            Some(Arc::new(
-                transport::transport_exec_bash::BashExecTransport::new(
-                    Arc::clone(&state),
-                    bash_cfg.root_dir.as_deref(),
-                    working_dir,
-                ),
-            ))
+            None => tracing::info!("Bash exec transport enabled (inline only)"),
         }
-        None => None,
+        let working_dir =
+            transport::transport_exec_bash::WorkingDir::from_config(&bash_cfg.working_dir);
+        Some(Arc::new(
+            transport::transport_exec_bash::BashExecTransport::new(
+                Arc::clone(&state),
+                bash_cfg.root_dir.as_deref(),
+                working_dir,
+            ),
+        ))
+    } else {
+        None
     };
     let dispatcher = Arc::new(transport::TransportDispatcher::new(
-        http_push,
-        poll_registry.clone(),
-        gcps,
-        bash,
+        http_push, http_poll, gcps, bash,
     ));
 
     // Spawn background loops

--- a/src/processing/processing_messages.rs
+++ b/src/processing/processing_messages.rs
@@ -119,3 +119,271 @@ pub async fn process_batch(
         dispatcher.send(&msg.address, &payload).await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use serde_json::json;
+
+    use crate::config::Config;
+    use crate::persistence::{persistence_sqlite::SqliteStorage, Storage};
+    use crate::server::{dispatch as server_dispatch, Server};
+    use crate::transport::stubs::{RecordingHttpTransport, RecordingPollTransport};
+    use crate::transport::{HttpTransport, PollTransport, TransportDispatcher};
+    use crate::types::{RequestEnvelope, RequestHead, SUPPORTED_VERSIONS};
+
+    // ---- helpers ----
+
+    fn make_server() -> Arc<Server> {
+        let sqlite = SqliteStorage::open(":memory:", 30_000).unwrap();
+        let storage = Storage::Sqlite(sqlite);
+        let mut config = Config::default();
+        config.server.url = Some("http://localhost:8001".to_string());
+        Arc::new(Server::new(config, None, storage))
+    }
+
+    fn req(kind: &str, data: serde_json::Value) -> RequestEnvelope {
+        RequestEnvelope {
+            kind: kind.to_string(),
+            head: RequestHead {
+                corr_id: "test".to_string(),
+                version: SUPPORTED_VERSIONS[0].to_string(),
+                auth: None,
+                debug_time: None,
+            },
+            data,
+        }
+    }
+
+    async fn dispatch(server: &Arc<Server>, kind: &str, data: serde_json::Value) {
+        let resp = server_dispatch(server, &req(kind, data), 1_000_000).await;
+        assert_eq!(resp.head.status, 200, "{kind} failed: {:?}", resp.data);
+    }
+
+    /// Create a task whose promise carries `resonate:target = address`, then
+    /// immediately release it so an outgoing_execute row is queued for delivery.
+    ///
+    /// task.create returns the task in "acquired" state (version 1).
+    /// task.release transitions it back to "pending" and inserts the
+    /// outgoing_execute row that process_batch will pick up.
+    async fn create_task_with_target(server: &Arc<Server>, task_id: &str, address: &str) {
+        dispatch(
+            server,
+            "task.create",
+            json!({
+                "pid": "test-worker",
+                "ttl": 60_000,
+                "action": {
+                    "kind": "promise.create",
+                    "head": {},
+                    "data": {
+                        "id": task_id,
+                        "timeoutAt": 2_000_000,
+                        "param": {},
+                        "tags": { "resonate:target": address }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        // Release puts the task back to pending and queues the outgoing_execute row.
+        dispatch(
+            server,
+            "task.release",
+            json!({ "id": task_id, "version": 1 }),
+        )
+        .await;
+    }
+
+    /// Register a poll listener on `promise_id` so settling it produces an
+    /// outgoing_unblock row addressed to `poll_address`.
+    async fn register_listener(server: &Arc<Server>, promise_id: &str, poll_address: &str) {
+        dispatch(
+            server,
+            "promise.register_listener",
+            json!({ "awaited": promise_id, "address": poll_address }),
+        )
+        .await;
+    }
+
+    async fn settle_promise(server: &Arc<Server>, promise_id: &str) {
+        dispatch(
+            server,
+            "promise.settle",
+            json!({ "id": promise_id, "state": "resolved", "value": {} }),
+        )
+        .await;
+    }
+
+    // ---- execute-message tests ----
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn execute_message_dispatched_when_http_push_enabled() {
+        let server = make_server();
+        create_task_with_target(&server, "task-1", "http://stub-server/webhook").await;
+
+        let stub = Arc::new(RecordingHttpTransport::new());
+        let dispatcher = TransportDispatcher::new(
+            Some(stub.clone() as Arc<dyn HttpTransport>),
+            None,
+            None,
+            None,
+        );
+
+        process_batch(&server.storage, &dispatcher, 100, "http://localhost:8001").await;
+
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1, "expected exactly one HTTP dispatch");
+        assert_eq!(calls[0].0, "http://stub-server/webhook");
+        assert_eq!(calls[0].1["kind"], "execute");
+        assert_eq!(calls[0].1["data"]["task"]["id"], "task-1");
+        assert_eq!(calls[0].1["head"]["serverUrl"], "http://localhost:8001");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn execute_message_dropped_but_dequeued_when_http_push_disabled() {
+        let server = make_server();
+        create_task_with_target(&server, "task-2", "http://stub-server/webhook").await;
+
+        // First pass: http_push disabled — message is consumed from queue and dropped.
+        let disabled = TransportDispatcher::new(None, None, None, None);
+        process_batch(&server.storage, &disabled, 100, "http://localhost:8001").await;
+
+        // Second pass: http_push now enabled — queue should already be empty.
+        let stub = Arc::new(RecordingHttpTransport::new());
+        let enabled = TransportDispatcher::new(
+            Some(stub.clone() as Arc<dyn HttpTransport>),
+            None,
+            None,
+            None,
+        );
+        process_batch(&server.storage, &enabled, 100, "http://localhost:8001").await;
+
+        assert_eq!(
+            stub.calls().len(),
+            0,
+            "message was already drained on the first pass; should not be re-delivered"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn execute_message_dispatched_when_poll_enabled() {
+        let server = make_server();
+        create_task_with_target(&server, "task-3", "poll://any@default").await;
+
+        let stub = Arc::new(RecordingPollTransport::new());
+        let dispatcher = TransportDispatcher::new(
+            None,
+            Some(stub.clone() as Arc<dyn PollTransport>),
+            None,
+            None,
+        );
+
+        process_batch(&server.storage, &dispatcher, 100, "http://localhost:8001").await;
+
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1, "expected exactly one poll dispatch");
+        assert_eq!(calls[0].0, "default");
+        let body: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(body["kind"], "execute");
+        assert_eq!(body["data"]["task"]["id"], "task-3");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn execute_message_dropped_but_dequeued_when_poll_disabled() {
+        let server = make_server();
+        create_task_with_target(&server, "task-4", "poll://any@default").await;
+
+        let disabled = TransportDispatcher::new(None, None, None, None);
+        process_batch(&server.storage, &disabled, 100, "http://localhost:8001").await;
+
+        let stub = Arc::new(RecordingPollTransport::new());
+        let enabled = TransportDispatcher::new(
+            None,
+            Some(stub.clone() as Arc<dyn PollTransport>),
+            None,
+            None,
+        );
+        process_batch(&server.storage, &enabled, 100, "http://localhost:8001").await;
+
+        assert_eq!(stub.calls().len(), 0);
+    }
+
+    // ---- unblock-message tests ----
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unblock_message_dispatched_when_http_poll_enabled() {
+        let server = make_server();
+
+        // Create a bare promise (no task) and register a poll listener on it.
+        dispatch(
+            &server,
+            "promise.create",
+            json!({
+                "id": "p-unblock-1",
+                "timeoutAt": 2_000_000,
+                "param": {},
+                "tags": {}
+            }),
+        )
+        .await;
+        register_listener(&server, "p-unblock-1", "poll://uni@worker-group/worker-1").await;
+        settle_promise(&server, "p-unblock-1").await;
+
+        let stub = Arc::new(RecordingPollTransport::new());
+        let dispatcher = TransportDispatcher::new(
+            None,
+            Some(stub.clone() as Arc<dyn PollTransport>),
+            None,
+            None,
+        );
+
+        process_batch(&server.storage, &dispatcher, 100, "http://localhost:8001").await;
+
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1, "expected exactly one unblock dispatch");
+        assert_eq!(calls[0].0, "worker-group");
+        let body: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(body["kind"], "unblock");
+        assert_eq!(body["data"]["promise"]["id"], "p-unblock-1");
+        assert_eq!(body["data"]["promise"]["state"], "resolved");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unblock_message_dropped_but_dequeued_when_http_poll_disabled() {
+        let server = make_server();
+
+        dispatch(
+            &server,
+            "promise.create",
+            json!({
+                "id": "p-unblock-2",
+                "timeoutAt": 2_000_000,
+                "param": {},
+                "tags": {}
+            }),
+        )
+        .await;
+        register_listener(&server, "p-unblock-2", "poll://uni@worker-group/worker-2").await;
+        settle_promise(&server, "p-unblock-2").await;
+
+        // First pass: poll disabled — message consumed and dropped.
+        let disabled = TransportDispatcher::new(None, None, None, None);
+        process_batch(&server.storage, &disabled, 100, "http://localhost:8001").await;
+
+        // Second pass: poll enabled — queue already drained.
+        let stub = Arc::new(RecordingPollTransport::new());
+        let enabled = TransportDispatcher::new(
+            None,
+            Some(stub.clone() as Arc<dyn PollTransport>),
+            None,
+            None,
+        );
+        process_batch(&server.storage, &enabled, 100, "http://localhost:8001").await;
+
+        assert_eq!(stub.calls().len(), 0);
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -3,28 +3,79 @@ pub mod transport_gcps;
 pub mod transport_http_poll;
 pub mod transport_http_push;
 
-use transport_exec_bash::BashExecTransport;
-use transport_gcps::GcpsPubSubTransport;
-use transport_http_poll::PollRegistry;
-use transport_http_push::HttpPushTransport;
-
 use std::sync::Arc;
+
+use async_trait::async_trait;
+
+// ---- Per-transport traits ----
+
+#[async_trait]
+pub trait HttpTransport: Send + Sync {
+    async fn send(&self, addr: &HttpAddress, payload: &serde_json::Value);
+}
+
+#[async_trait]
+pub trait PollTransport: Send + Sync {
+    async fn send(&self, addr: &PollAddress, payload: &str) -> bool;
+}
+
+#[async_trait]
+pub trait GcpsTransport: Send + Sync {
+    async fn send(&self, addr: &GcpsAddress, payload: &serde_json::Value);
+}
+
+#[async_trait]
+pub trait BashTransport: Send + Sync {
+    async fn send(&self, address: &str, payload: &serde_json::Value);
+}
+
+// ---- Trait impls for real transport types ----
+
+#[async_trait]
+impl HttpTransport for transport_http_push::HttpPushTransport {
+    async fn send(&self, addr: &HttpAddress, payload: &serde_json::Value) {
+        transport_http_push::HttpPushTransport::send(self, addr, payload).await
+    }
+}
+
+#[async_trait]
+impl PollTransport for transport_http_poll::PollRegistry {
+    async fn send(&self, addr: &PollAddress, payload: &str) -> bool {
+        transport_http_poll::PollRegistry::send_poll(self, addr, payload).await
+    }
+}
+
+#[async_trait]
+impl GcpsTransport for transport_gcps::GcpsPubSubTransport {
+    async fn send(&self, addr: &GcpsAddress, payload: &serde_json::Value) {
+        transport_gcps::GcpsPubSubTransport::send(self, addr, payload).await
+    }
+}
+
+#[async_trait]
+impl BashTransport for transport_exec_bash::BashExecTransport {
+    async fn send(&self, address: &str, payload: &serde_json::Value) {
+        transport_exec_bash::BashExecTransport::send(self, address, payload).await
+    }
+}
+
+// ---- Dispatcher ----
 
 /// Dispatches messages to the appropriate transport by parsing the address once.
 /// Routes by URL scheme: http/https → push, poll → SSE, gcps → GCP Pub/Sub, bash → bash exec.
 pub struct TransportDispatcher {
-    http: Arc<HttpPushTransport>,
-    poll: Arc<PollRegistry>,
-    gcps: Option<Arc<GcpsPubSubTransport>>,
-    bash: Option<Arc<BashExecTransport>>,
+    http: Option<Arc<dyn HttpTransport>>,
+    poll: Option<Arc<dyn PollTransport>>,
+    gcps: Option<Arc<dyn GcpsTransport>>,
+    bash: Option<Arc<dyn BashTransport>>,
 }
 
 impl TransportDispatcher {
     pub fn new(
-        http: Arc<HttpPushTransport>,
-        poll: Arc<PollRegistry>,
-        gcps: Option<Arc<GcpsPubSubTransport>>,
-        bash: Option<Arc<BashExecTransport>>,
+        http: Option<Arc<dyn HttpTransport>>,
+        poll: Option<Arc<dyn PollTransport>>,
+        gcps: Option<Arc<dyn GcpsTransport>>,
+        bash: Option<Arc<dyn BashTransport>>,
     ) -> Self {
         Self {
             http,
@@ -41,15 +92,25 @@ impl TransportDispatcher {
             .and_then(|v| v.as_str())
             .unwrap_or("unknown");
         match parse_address(address) {
-            Some(Address::Http(addr)) => {
-                tracing::debug!(transport = "http", address = %addr.url, kind = kind, "Dispatching message via HTTP push");
-                self.http.send(&addr, payload).await;
-            }
-            Some(Address::Poll(addr)) => {
-                tracing::debug!(transport = "poll", group = %addr.group, kind = kind, "Dispatching message via poll/SSE");
-                let sse_data = serde_json::to_string(payload).unwrap_or_default();
-                self.poll.send_poll(&addr, &sse_data).await;
-            }
+            Some(Address::Http(addr)) => match &self.http {
+                Some(http) => {
+                    tracing::debug!(transport = "http", address = %addr.url, kind = kind, "Dispatching message via HTTP push");
+                    http.send(&addr, payload).await;
+                }
+                None => {
+                    tracing::warn!(address = %address, "HTTP push transport disabled, message dropped")
+                }
+            },
+            Some(Address::Poll(addr)) => match &self.poll {
+                Some(poll) => {
+                    tracing::debug!(transport = "poll", group = %addr.group, kind = kind, "Dispatching message via poll/SSE");
+                    let sse_data = serde_json::to_string(payload).unwrap_or_default();
+                    poll.send(&addr, &sse_data).await;
+                }
+                None => {
+                    tracing::warn!(address = %address, "HTTP poll transport disabled, message dropped")
+                }
+            },
             Some(Address::Gcps(addr)) => match &self.gcps {
                 Some(gcps) => {
                     tracing::debug!(transport = "gcps", project = %addr.project, topic = %addr.topic, kind = kind, "Dispatching message via GCP Pub/Sub");
@@ -79,6 +140,8 @@ impl TransportDispatcher {
         }
     }
 }
+
+// ---- Address types ----
 
 /// Parsed address — determines which transport and where to deliver.
 #[derive(Debug, Clone)]
@@ -172,9 +235,250 @@ pub fn parse_address(address: &str) -> Option<Address> {
     }
 }
 
+// ---- Test stubs ----
+
+#[cfg(test)]
+pub mod stubs {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Records every (url, payload) pair delivered via HTTP push.
+    pub struct RecordingHttpTransport {
+        pub calls: Mutex<Vec<(String, serde_json::Value)>>,
+    }
+
+    impl RecordingHttpTransport {
+        pub fn new() -> Self {
+            Self {
+                calls: Mutex::new(vec![]),
+            }
+        }
+
+        pub fn calls(&self) -> Vec<(String, serde_json::Value)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl HttpTransport for RecordingHttpTransport {
+        async fn send(&self, addr: &HttpAddress, payload: &serde_json::Value) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((addr.url.clone(), payload.clone()));
+        }
+    }
+
+    /// Records every (group, payload_str) pair delivered via poll/SSE.
+    pub struct RecordingPollTransport {
+        pub calls: Mutex<Vec<(String, String)>>,
+    }
+
+    impl RecordingPollTransport {
+        pub fn new() -> Self {
+            Self {
+                calls: Mutex::new(vec![]),
+            }
+        }
+
+        pub fn calls(&self) -> Vec<(String, String)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl PollTransport for RecordingPollTransport {
+        async fn send(&self, addr: &PollAddress, payload: &str) -> bool {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((addr.group.clone(), payload.to_string()));
+            true
+        }
+    }
+
+    /// Records every (project/topic, payload) pair delivered via GCP Pub/Sub.
+    pub struct RecordingGcpsTransport {
+        pub calls: Mutex<Vec<(String, serde_json::Value)>>,
+    }
+
+    impl RecordingGcpsTransport {
+        pub fn new() -> Self {
+            Self {
+                calls: Mutex::new(vec![]),
+            }
+        }
+
+        pub fn calls(&self) -> Vec<(String, serde_json::Value)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl GcpsTransport for RecordingGcpsTransport {
+        async fn send(&self, addr: &GcpsAddress, payload: &serde_json::Value) {
+            let key = format!("{}/{}", addr.project, addr.topic);
+            self.calls.lock().unwrap().push((key, payload.clone()));
+        }
+    }
+
+    /// Records every (address, payload) pair delivered via bash exec.
+    pub struct RecordingBashTransport {
+        pub calls: Mutex<Vec<(String, serde_json::Value)>>,
+    }
+
+    impl RecordingBashTransport {
+        pub fn new() -> Self {
+            Self {
+                calls: Mutex::new(vec![]),
+            }
+        }
+
+        pub fn calls(&self) -> Vec<(String, serde_json::Value)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl BashTransport for RecordingBashTransport {
+        async fn send(&self, address: &str, payload: &serde_json::Value) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((address.to_string(), payload.clone()));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::stubs::*;
     use super::*;
+    use serde_json::json;
+
+    fn payload(kind: &str) -> serde_json::Value {
+        json!({ "kind": kind, "head": {}, "data": {} })
+    }
+
+    fn dispatcher_with_http(stub: Arc<RecordingHttpTransport>) -> TransportDispatcher {
+        TransportDispatcher::new(Some(stub as Arc<dyn HttpTransport>), None, None, None)
+    }
+
+    fn dispatcher_with_poll(stub: Arc<RecordingPollTransport>) -> TransportDispatcher {
+        TransportDispatcher::new(None, Some(stub as Arc<dyn PollTransport>), None, None)
+    }
+
+    fn dispatcher_with_gcps(stub: Arc<RecordingGcpsTransport>) -> TransportDispatcher {
+        TransportDispatcher::new(None, None, Some(stub as Arc<dyn GcpsTransport>), None)
+    }
+
+    fn dispatcher_with_bash(stub: Arc<RecordingBashTransport>) -> TransportDispatcher {
+        TransportDispatcher::new(None, None, None, Some(stub as Arc<dyn BashTransport>))
+    }
+
+    // ---- http_push ----
+
+    #[tokio::test]
+    async fn http_push_enabled_routes_to_stub() {
+        let stub = Arc::new(RecordingHttpTransport::new());
+        let dispatcher = dispatcher_with_http(stub.clone());
+        dispatcher
+            .send("http://example.com/callback", &payload("execute"))
+            .await;
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "http://example.com/callback");
+        assert_eq!(calls[0].1["kind"], "execute");
+    }
+
+    #[tokio::test]
+    async fn http_push_disabled_drops_without_error() {
+        let dispatcher = TransportDispatcher::new(None, None, None, None);
+        // Should return without panicking — message silently dropped
+        dispatcher
+            .send("http://example.com/callback", &payload("execute"))
+            .await;
+    }
+
+    #[tokio::test]
+    async fn https_push_enabled_routes_to_stub() {
+        let stub = Arc::new(RecordingHttpTransport::new());
+        let dispatcher = dispatcher_with_http(stub.clone());
+        dispatcher
+            .send("https://example.com/secure", &payload("execute"))
+            .await;
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "https://example.com/secure");
+    }
+
+    // ---- http_poll ----
+
+    #[tokio::test]
+    async fn http_poll_enabled_routes_to_stub() {
+        let stub = Arc::new(RecordingPollTransport::new());
+        let dispatcher = dispatcher_with_poll(stub.clone());
+        dispatcher
+            .send("poll://any@default", &payload("execute"))
+            .await;
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "default");
+        let body: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(body["kind"], "execute");
+    }
+
+    #[tokio::test]
+    async fn http_poll_disabled_drops_without_error() {
+        let dispatcher = TransportDispatcher::new(None, None, None, None);
+        dispatcher
+            .send("poll://any@default", &payload("execute"))
+            .await;
+    }
+
+    // ---- gcps ----
+
+    #[tokio::test]
+    async fn gcps_enabled_routes_to_stub() {
+        let stub = Arc::new(RecordingGcpsTransport::new());
+        let dispatcher = dispatcher_with_gcps(stub.clone());
+        dispatcher
+            .send("gcps://my-project/my-topic", &payload("execute"))
+            .await;
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "my-project/my-topic");
+        assert_eq!(calls[0].1["kind"], "execute");
+    }
+
+    #[tokio::test]
+    async fn gcps_disabled_drops_without_error() {
+        let dispatcher = TransportDispatcher::new(None, None, None, None);
+        dispatcher
+            .send("gcps://my-project/my-topic", &payload("execute"))
+            .await;
+    }
+
+    // ---- bash ----
+
+    #[tokio::test]
+    async fn bash_enabled_routes_to_stub() {
+        let stub = Arc::new(RecordingBashTransport::new());
+        let dispatcher = dispatcher_with_bash(stub.clone());
+        // bash:// is the inline-script address scheme
+        dispatcher.send("bash://", &payload("execute")).await;
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "bash://");
+        assert_eq!(calls[0].1["kind"], "execute");
+    }
+
+    #[tokio::test]
+    async fn bash_disabled_drops_without_error() {
+        let dispatcher = TransportDispatcher::new(None, None, None, None);
+        dispatcher.send("bash://", &payload("execute")).await;
+    }
+
     #[test]
     fn bash_address_parses() {
         assert!(matches!(parse_address("bash://"), Some(Address::Bash(_))));


### PR DESCRIPTION
Add --transports-{http-push,http-poll,gcps,bash-exec}-enabled CLI flags and corresponding config fields; refactor TransportDispatcher to hold Option<Arc<dyn Trait>> for each transport and add recording stubs with tests.